### PR TITLE
fix: update deployment guide — Fly.io is NOT free, recommend Render.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,79 +30,56 @@ This starts both the server (port 3000) and client (port 5173).
 
 ## Deploy for Free
 
-This project is designed to run for **$0/month** using free hosting tiers. Here are your options:
+This project is designed to run for **$0/month**. Here are your options, sorted by cost:
 
-### Option 1: Fly.io (Recommended)
+### Option 1: Render.com (Recommended — Free, No Credit Card)
 
-Fly.io offers a generous free tier with WebSocket support and persistent storage.
-
-```bash
-# 1. Install the Fly CLI
-curl -L https://fly.io/install.sh | sh
-
-# 2. Sign up (free, no credit card needed for hobby plan)
-fly auth signup
-
-# 3. Launch your app (from the project root)
-fly launch --no-deploy
-
-# 4. Create a volume for the database
-fly volumes create makruk_data --size 1 --region sin
-
-# 5. Deploy
-fly deploy
-
-# Your app is now live at https://your-app-name.fly.dev
-```
-
-**Cost: $0/month** on the free tier (3 shared VMs, 3GB storage).
-
-### Option 2: Render.com
+Render.com is the best free option. **No credit card required.** WebSocket support included.
 
 ```bash
 # 1. Push your code to GitHub
-# 2. Go to render.com, sign up free
-# 3. Create a "Web Service", connect your repo
-# 4. Set:
-#    - Build Command: npm install && npm run build --workspace=client
-#    - Start Command: npx tsx server/src/index.ts
-#    - Environment: NODE_ENV=production
+# 2. Go to render.com, sign up with GitHub (free, no credit card)
+# 3. Click "New" → "Blueprint" → select your repo
+# 4. Render reads the render.yaml and deploys automatically
+# 5. Your app is live at https://your-app.onrender.com
 ```
 
-**Cost: $0/month** on free tier (spins down after 15min inactivity).
+Or manually: New → Web Service → connect repo → set:
+- **Build Command:** `npm install && npm run build --workspace=client`
+- **Start Command:** `npx tsx server/src/index.ts`
+- **Environment:** `NODE_ENV=production`
 
-### Option 3: Railway.app
+**Cost: $0/month** — 750 free hours/month. Service sleeps after 15min idle, wakes in ~30s on first request. WebSocket activity keeps it awake during games.
 
-```bash
-# 1. Push your code to GitHub
-# 2. Go to railway.app, sign up with GitHub
-# 3. Create a project from your repo
-# 4. It auto-detects the Dockerfile and deploys
-```
+> **Note:** Free tier has ephemeral storage — game history resets on redeploy. This is fine for starting out. Upgrade to a paid plan ($7/mo) later for persistent storage.
 
-**Cost: $0-5/month** ($5 free credit monthly).
+### Option 2: Self-host (Free Forever with Oracle Cloud)
 
-### Option 4: Self-host (VPS)
-
-For maximum control, use a free Oracle Cloud VM or any $5/month VPS:
+Oracle Cloud offers **always-free** VMs that never expire. Best for persistent storage.
 
 ```bash
-# On your server:
-git clone https://github.com/YOUR_USERNAME/makrukthai.git
-cd makrukthai
+# 1. Sign up at cloud.oracle.com (free tier, credit card for verification only — never charged)
+# 2. Create a free "Always Free" VM (ARM, 4 CPU, 24GB RAM)
+# 3. SSH in and run:
+git clone https://github.com/YOUR_USERNAME/markrukthai.git
+cd markrukthai
 npm install
 npm run build --workspace=client
 NODE_ENV=production npx tsx server/src/index.ts
 ```
 
-Use `nginx` as a reverse proxy with a free SSL certificate from Let's Encrypt.
+Use `nginx` + Let's Encrypt for HTTPS. **Cost: $0/month forever.**
 
-### Option 5: Docker (Any Platform)
+### Option 3: Docker (Any Platform)
 
 ```bash
 docker build -t makruk .
 docker run -p 3000:3000 -v makruk-data:/data makruk
 ```
+
+### ⚠️ About Fly.io
+
+Fly.io **no longer has a free tier** (as of 2024). Their "Pay As You Go" plan at $0/mo will charge you after a 2-hour trial. Minimum cost is ~$3-5/month. Only use Fly.io if you're willing to pay.
 
 ## Makruk Rules
 

--- a/fly.toml
+++ b/fly.toml
@@ -1,6 +1,7 @@
 # Fly.io configuration for Makruk Thai Chess
+# WARNING: Fly.io no longer has a free tier (as of 2024).
+# This will cost ~$3-5/month. Use Render.com for free hosting instead.
 # Deploy: fly launch --no-deploy && fly deploy
-# Or: fly deploy (after initial setup)
 
 app = 'makruk-thai'
 primary_region = 'sin' # Singapore - close to Thailand

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,12 @@
+services:
+  - type: web
+    name: makruk-thai-chess
+    runtime: node
+    plan: free
+    buildCommand: npm install && npm run build --workspace=client
+    startCommand: npx tsx server/src/index.ts
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: NODE_VERSION
+        value: 22


### PR DESCRIPTION
- Fly.io no longer has a free tier (charges after 2hr trial)
- Render.com is now the recommended deployment (truly free, no credit card)
- Added render.yaml for one-click Render deployment
- Added Oracle Cloud as free self-host option
- Updated README with honest cost information
- Added warning to fly.toml about costs

## What does this PR do?

Brief description of the changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] Code compiles without errors (`npx tsc --noEmit`)
- [ ] Client builds successfully (`npm run build --workspace=client`)
- [ ] Tested locally
- [ ] No console errors in browser
