### PR TITLE
refactor: move deployment docs to private DEPLOY.md, clean up README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Private docs (local only, not pushed to GitHub)
+DEPLOY.md
+
 # Dependencies
 node_modules/
 

--- a/README.md
+++ b/README.md
@@ -11,88 +11,35 @@ A free, open-source Makruk (Thai Chess) platform inspired by [Lichess](https://l
 - **Local Play** — Practice on the same screen at `/local`
 - **Time Controls** — Bullet, Blitz, Rapid, and Classical presets
 - **Full Makruk Rules** — Complete Thai Chess engine with all 6 piece types
-- **Game History** — All completed games saved to database, browsable at `/games`
+- **Game History** — All completed games saved and browsable at `/games`
 - **Beautiful UI** — Lichess-inspired dark theme with custom SVG pieces
 - **Drag & Drop** — Move pieces by dragging or clicking
-- **Mobile Friendly** — Touch support and responsive design
+- **Mobile Friendly** — Touch support, responsive design, installable as PWA
 - **Sound Effects** — Audio feedback for moves, captures, and checks
 - **Game Controls** — Draw offers, resignation, and rematch
 - **100% Free** — No ads, no paywall, no registration
 
-## Quick Start
+## Quick Start (Development)
 
 ```bash
 npm install
 npm run dev
 ```
 
-This starts both the server (port 3000) and client (port 5173).
-
-## Deploy for Free
-
-This project is designed to run for **$0/month**. Here are your options, sorted by cost:
-
-### Option 1: Render.com (Recommended — Free, No Credit Card)
-
-Render.com is the best free option. **No credit card required.** WebSocket support included.
-
-```bash
-# 1. Push your code to GitHub
-# 2. Go to render.com, sign up with GitHub (free, no credit card)
-# 3. Click "New" → "Blueprint" → select your repo
-# 4. Render reads the render.yaml and deploys automatically
-# 5. Your app is live at https://your-app.onrender.com
-```
-
-Or manually: New → Web Service → connect repo → set:
-- **Build Command:** `npm install && npm run build --workspace=client`
-- **Start Command:** `npx tsx server/src/index.ts`
-- **Environment:** `NODE_ENV=production`
-
-**Cost: $0/month** — 750 free hours/month. Service sleeps after 15min idle, wakes in ~30s on first request. WebSocket activity keeps it awake during games.
-
-> **Note:** Free tier has ephemeral storage — game history resets on redeploy. This is fine for starting out. Upgrade to a paid plan ($7/mo) later for persistent storage.
-
-### Option 2: Self-host (Free Forever with Oracle Cloud)
-
-Oracle Cloud offers **always-free** VMs that never expire. Best for persistent storage.
-
-```bash
-# 1. Sign up at cloud.oracle.com (free tier, credit card for verification only — never charged)
-# 2. Create a free "Always Free" VM (ARM, 4 CPU, 24GB RAM)
-# 3. SSH in and run:
-git clone https://github.com/YOUR_USERNAME/markrukthai.git
-cd markrukthai
-npm install
-npm run build --workspace=client
-NODE_ENV=production npx tsx server/src/index.ts
-```
-
-Use `nginx` + Let's Encrypt for HTTPS. **Cost: $0/month forever.**
-
-### Option 3: Docker (Any Platform)
-
-```bash
-docker build -t makruk .
-docker run -p 3000:3000 -v makruk-data:/data makruk
-```
-
-### ⚠️ About Fly.io
-
-Fly.io **no longer has a free tier** (as of 2024). Their "Pay As You Go" plan at $0/mo will charge you after a 2-hour trial. Minimum cost is ~$3-5/month. Only use Fly.io if you're willing to pay.
+This starts both the server (port 3000) and client (port 5173). Open http://localhost:5173 to play.
 
 ## Makruk Rules
 
-Makruk (หมากรุก) is the traditional chess of Thailand.
+Makruk (หมากรุก) is the traditional chess of Thailand, closely related to the ancient Indian game Chaturanga.
 
-| Piece | Thai Name | Symbol | Movement |
-|-------|-----------|--------|----------|
-| Khun (King) | ขุน | ♚ | 1 square in any direction |
-| Met (Queen) | เม็ด | ♛ | 1 square diagonally |
-| Khon (Bishop) | โคน | ⛊ | 1 square diagonally or 1 forward |
-| Rua (Rook) | เรือ | ♜ | Any distance horizontally/vertically |
-| Ma (Knight) | ม้า | ♞ | L-shape (same as chess) |
-| Bia (Pawn) | เบี้ย | ♟ | 1 forward; captures diagonally |
+| Piece | Thai Name | Movement |
+|-------|-----------|----------|
+| Khun (King) | ขุน | 1 square in any direction |
+| Met (Queen) | เม็ด | 1 square diagonally |
+| Khon (Bishop) | โคน | 1 square diagonally or 1 forward |
+| Rua (Rook) | เรือ | Any distance horizontally/vertically |
+| Ma (Knight) | ม้า | L-shape (same as chess) |
+| Bia (Pawn) | เบี้ย | 1 forward; captures diagonally |
 
 **Key differences from Western Chess:**
 - Pawns start on the 3rd rank and promote on the 6th rank (to Met)
@@ -125,30 +72,29 @@ Makruk (หมากรุก) is the traditional chess of Thailand.
 │       ├── components/      # Board, pieces, pages
 │       └── lib/             # Socket client, sounds
 ├── Dockerfile         # Container deployment
-├── fly.toml           # Fly.io config
 └── package.json       # Workspace root
 ```
 
 ## Contributing
 
-We'd love your help making Makruk famous! Here's how:
+We'd love your help making Makruk famous! See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 1. **Star this repo** — helps others discover it
-2. **Play and share** — invite your friends to play
-3. **Report bugs** — open GitHub issues
-4. **Submit PRs** — code contributions welcome
-5. **Translate** — help us add Thai and other languages
+2. **Play and share** — invite your friends
+3. **Report bugs** — [open an issue](../../issues/new?template=bug_report.md)
+4. **Request features** — [suggest ideas](../../issues/new?template=feature_request.md)
+5. **Submit PRs** — code contributions welcome
+6. **Translate** — help us add Thai and other languages
 
 ## Roadmap
 
+- [ ] Thai language support (ภาษาไทย)
 - [ ] Player accounts (optional, anonymous play always available)
 - [ ] ELO rating system
 - [ ] Puzzles and tactics trainer
-- [ ] Game analysis and engine evaluation
-- [ ] Thai language support (ภาษาไทย)
-- [ ] Tournaments
-- [ ] Mobile app (PWA)
+- [ ] Game analysis
 - [ ] AI opponent
+- [ ] Tournaments
 - [ ] Makruk counting rules (full implementation)
 - [ ] Spectator mode improvements
 


### PR DESCRIPTION
- Created DEPLOY.md with comprehensive GitHub Student Pack research
  - DigitalOcean 00 credits (verified available, best option)
  - Azure cd /workspace && git add -A && git commit -m "refactor: move deployment docs to private DEPLOY.md, clean up README

- Created DEPLOY.md with comprehensive GitHub Student Pack research
  - DigitalOcean $200 credits (verified available, best option)
  - Azure $100 credits (verified, but DigitalOcean is simpler)
  - MongoDB Atlas $50 credits (verified, not needed yet)
  - Vercel Pro (verified, but not suitable for WebSocket apps)
  - Full DigitalOcean deployment walkthrough with systemd + nginx
- Added DEPLOY.md to .gitignore (stays local, not pushed to GitHub)
- Cleaned up README: removed all deployment sections
- README now focuses on project description, rules, contributing"00 credits (verified, but DigitalOcean is simpler)
  - MongoDB Atlas 0 credits (verified, not needed yet)
  - Vercel Pro (verified, but not suitable for WebSocket apps)
  - Full DigitalOcean deployment walkthrough with systemd + nginx
- Added DEPLOY.md to .gitignore (stays local, not pushed to GitHub)
- Cleaned up README: removed all deployment sections
- README now focuses on project description, rules, contributing

## What does this PR do?

Brief description of the changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] Code compiles without errors (`npx tsc --noEmit`)
- [ ] Client builds successfully (`npm run build --workspace=client`)
- [ ] Tested locally
- [ ] No console errors in browser
