### PR TITLE
feat: add feedback messages display page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import { PuzzleListPage, PuzzlePlayer } from './components/PuzzlePage';
 import QuickPlay from './components/QuickPlay';
 import AboutPage from './components/AboutPage';
 import GamesPage from './components/GamesPage';
+import FeedbackMessagesPage from './components/FeedbackMessagesPage';
 import FeedbackWidget from './components/FeedbackWidget';
 
 export default function App() {
@@ -22,6 +23,7 @@ export default function App() {
         <Route path="/quick-play" element={<QuickPlay />} />
         <Route path="/about" element={<AboutPage />} />
         <Route path="/games" element={<GamesPage />} />
+        <Route path="/feedback" element={<FeedbackMessagesPage />} />
       </Routes>
       <FeedbackWidget />
     </div>

--- a/client/src/components/FeedbackMessagesPage.tsx
+++ b/client/src/components/FeedbackMessagesPage.tsx
@@ -1,0 +1,182 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from '../lib/i18n';
+import Header from './Header';
+
+interface FeedbackEntry {
+  id: number;
+  type: string;
+  message: string;
+  page: string;
+  user_agent: string;
+  created_at: number;
+}
+
+type FilterType = 'all' | 'bug' | 'feature' | 'other';
+
+const TYPE_STYLES: Record<string, { bg: string; text: string; icon: string }> = {
+  bug: { bg: 'bg-red-500/15', text: 'text-red-400', icon: '🐛' },
+  feature: { bg: 'bg-blue-500/15', text: 'text-blue-400', icon: '✨' },
+  other: { bg: 'bg-amber-500/15', text: 'text-amber-400', icon: '💬' },
+};
+
+export default function FeedbackMessagesPage() {
+  const { t } = useTranslation();
+  const [feedback, setFeedback] = useState<FeedbackEntry[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(0);
+  const [filter, setFilter] = useState<FilterType>('all');
+  const [loading, setLoading] = useState(true);
+  const [expanded, setExpanded] = useState<number | null>(null);
+
+  const limit = 20;
+
+  function timeAgo(timestamp: number): string {
+    const seconds = Math.floor(Date.now() / 1000 - timestamp);
+    if (seconds < 60) return t('time.just_now');
+    if (seconds < 3600) return t('time.min_ago', { n: Math.floor(seconds / 60) });
+    if (seconds < 86400) return t('time.hour_ago', { n: Math.floor(seconds / 3600) });
+    if (seconds < 604800) return t('time.day_ago', { n: Math.floor(seconds / 86400) });
+    return new Date(timestamp * 1000).toLocaleDateString();
+  }
+
+  useEffect(() => {
+    setLoading(true);
+    const params = new URLSearchParams({ page: String(page), limit: String(limit) });
+    if (filter !== 'all') params.set('type', filter);
+
+    fetch(`/api/feedback?${params}`)
+      .then(r => r.json())
+      .then(data => {
+        setFeedback(data.feedback || []);
+        setTotal(data.total || 0);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, [page, filter]);
+
+  useEffect(() => {
+    setPage(0);
+  }, [filter]);
+
+  const totalPages = Math.ceil(total / limit);
+
+  const filterButton = (type: FilterType, label: string) => (
+    <button
+      key={type}
+      onClick={() => setFilter(type)}
+      className={`
+        px-3 py-1.5 rounded-lg text-xs sm:text-sm font-medium transition-all duration-150
+        ${filter === type
+          ? 'bg-primary text-white shadow-sm'
+          : 'bg-surface-alt border border-surface-hover text-text-dim hover:text-text-bright hover:bg-surface-hover'
+        }
+      `}
+    >
+      {label}
+    </button>
+  );
+
+  return (
+    <div className="min-h-screen bg-surface flex flex-col">
+      <Header active="about" />
+
+      <main className="flex-1 max-w-4xl mx-auto px-4 sm:px-6 py-4 sm:py-6 w-full">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mb-4 sm:mb-6">
+          <h2 className="text-xl sm:text-2xl font-bold text-text-bright">{t('feedback_page.title')}</h2>
+          <span className="text-text-dim text-xs sm:text-sm">{t('feedback_page.count', { count: total })}</span>
+        </div>
+
+        <div className="flex items-center gap-2 mb-4 flex-wrap">
+          {filterButton('all', t('feedback_page.filter_all'))}
+          {filterButton('bug', `🐛 ${t('feedback.bug')}`)}
+          {filterButton('feature', `✨ ${t('feedback.feature')}`)}
+          {filterButton('other', `💬 ${t('feedback.other')}`)}
+        </div>
+
+        {loading ? (
+          <div className="flex justify-center py-12">
+            <div className="w-10 h-10 border-4 border-primary border-t-transparent rounded-full animate-spin" />
+          </div>
+        ) : feedback.length === 0 ? (
+          <div className="text-center py-12 sm:py-16">
+            <div className="text-4xl mb-4">📭</div>
+            <p className="text-text-dim text-base sm:text-lg mb-2">{t('feedback_page.empty')}</p>
+            <p className="text-text-dim text-sm">{t('feedback_page.empty_desc')}</p>
+          </div>
+        ) : (
+          <>
+            <div className="space-y-3">
+              {feedback.map(item => {
+                const style = TYPE_STYLES[item.type] || TYPE_STYLES.other;
+                const isExpanded = expanded === item.id;
+
+                return (
+                  <div
+                    key={item.id}
+                    onClick={() => setExpanded(isExpanded ? null : item.id)}
+                    className="bg-surface-alt rounded-xl border border-surface-hover p-4 hover:border-surface-hover/80 transition-all duration-150 cursor-pointer"
+                  >
+                    <div className="flex items-start gap-3">
+                      <span className={`shrink-0 inline-flex items-center px-2 py-0.5 rounded-md text-xs font-semibold ${style.bg} ${style.text}`}>
+                        {style.icon} {item.type}
+                      </span>
+
+                      <div className="flex-1 min-w-0">
+                        <p className={`text-text-bright text-sm ${isExpanded ? '' : 'line-clamp-2'}`}>
+                          {item.message}
+                        </p>
+
+                        {isExpanded && (
+                          <div className="mt-3 pt-3 border-t border-surface-hover/50 space-y-1.5">
+                            <div className="flex items-center gap-2 text-xs text-text-dim">
+                              <span className="font-medium">{t('feedback_page.detail_page')}:</span>
+                              <span className="font-mono">{item.page || '—'}</span>
+                            </div>
+                            <div className="flex items-center gap-2 text-xs text-text-dim">
+                              <span className="font-medium">{t('feedback_page.detail_date')}:</span>
+                              <span>{new Date(item.created_at * 1000).toLocaleString()}</span>
+                            </div>
+                          </div>
+                        )}
+                      </div>
+
+                      <span className="shrink-0 text-text-dim text-xs whitespace-nowrap">
+                        {timeAgo(item.created_at)}
+                      </span>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+
+            {totalPages > 1 && (
+              <div className="flex items-center justify-center gap-2 mt-4 flex-wrap">
+                <button
+                  onClick={() => setPage(p => Math.max(0, p - 1))}
+                  disabled={page === 0}
+                  className="px-3 py-1.5 bg-surface-alt border border-surface-hover rounded text-sm disabled:opacity-30 hover:bg-surface-hover transition-colors text-text"
+                >
+                  ← {t('games.prev')}
+                </button>
+                <span className="text-text-dim text-xs sm:text-sm px-3">
+                  {t('games.page', { current: page + 1, total: totalPages })}
+                </span>
+                <button
+                  onClick={() => setPage(p => Math.min(totalPages - 1, p + 1))}
+                  disabled={page >= totalPages - 1}
+                  className="px-3 py-1.5 bg-surface-alt border border-surface-hover rounded text-sm disabled:opacity-30 hover:bg-surface-hover transition-colors text-text"
+                >
+                  {t('games.next')} →
+                </button>
+              </div>
+            )}
+          </>
+        )}
+      </main>
+
+      <footer className="bg-surface-alt border-t border-surface-hover py-4 px-4 text-center text-text-dim text-xs sm:text-sm">
+        {t('footer.tagline')}
+      </footer>
+    </div>
+  );
+}

--- a/client/src/lib/i18n.tsx
+++ b/client/src/lib/i18n.tsx
@@ -280,6 +280,15 @@ const EN: Record<string, string> = {
   'feedback.thanks_desc': 'Your feedback helps improve Makruk Online.',
   'feedback.error': 'Failed to send. Please try again.',
 
+  // Feedback Messages Page
+  'feedback_page.title': 'Feedback Messages',
+  'feedback_page.count': '{count} message(s)',
+  'feedback_page.filter_all': 'All',
+  'feedback_page.empty': 'No feedback yet',
+  'feedback_page.empty_desc': 'Feedback submitted by users will appear here.',
+  'feedback_page.detail_page': 'Page',
+  'feedback_page.detail_date': 'Date',
+
   // Time ago
   'time.just_now': 'just now',
   'time.min_ago': '{n}m ago',
@@ -549,6 +558,15 @@ const TH: Record<string, string> = {
   'feedback.thanks': 'ขอบคุณ!',
   'feedback.thanks_desc': 'ความคิดเห็นของคุณช่วยพัฒนาหมากรุกออนไลน์',
   'feedback.error': 'ส่งไม่สำเร็จ กรุณาลองใหม่',
+
+  // Feedback Messages Page
+  'feedback_page.title': 'ข้อความแจ้งปัญหา',
+  'feedback_page.count': '{count} ข้อความ',
+  'feedback_page.filter_all': 'ทั้งหมด',
+  'feedback_page.empty': 'ยังไม่มีข้อความ',
+  'feedback_page.empty_desc': 'ข้อความจากผู้ใช้จะแสดงที่นี่',
+  'feedback_page.detail_page': 'หน้า',
+  'feedback_page.detail_date': 'วันที่',
 
   // Time ago
   'time.just_now': 'เมื่อสักครู่',

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -165,3 +165,51 @@ export function saveFeedback(data: {
     console.error('Failed to save feedback:', err);
   }
 }
+
+export interface SavedFeedback {
+  id: number;
+  type: string;
+  message: string;
+  page: string;
+  user_agent: string;
+  ip: string;
+  created_at: number;
+}
+
+export function getFeedback(limit: number = 20, offset: number = 0, type?: string): SavedFeedback[] {
+  try {
+    if (type && type !== 'all') {
+      const stmt = db.prepare(`
+        SELECT id, type, message, page, user_agent, created_at FROM feedback
+        WHERE type = ?
+        ORDER BY created_at DESC
+        LIMIT ? OFFSET ?
+      `);
+      return stmt.all(type, limit, offset) as SavedFeedback[];
+    }
+    const stmt = db.prepare(`
+      SELECT id, type, message, page, user_agent, created_at FROM feedback
+      ORDER BY created_at DESC
+      LIMIT ? OFFSET ?
+    `);
+    return stmt.all(limit, offset) as SavedFeedback[];
+  } catch (err) {
+    console.error('Failed to get feedback:', err);
+    return [];
+  }
+}
+
+export function getFeedbackCount(type?: string): number {
+  try {
+    if (type && type !== 'all') {
+      const stmt = db.prepare('SELECT COUNT(*) as count FROM feedback WHERE type = ?');
+      const row = stmt.get(type) as { count: number };
+      return row.count;
+    }
+    const stmt = db.prepare('SELECT COUNT(*) as count FROM feedback');
+    const row = stmt.get() as { count: number };
+    return row.count;
+  } catch (err) {
+    return 0;
+  }
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -6,7 +6,7 @@ import path from 'path';
 import rateLimit from 'express-rate-limit';
 import { GameManager } from './gameManager';
 import { MatchmakingQueue } from './matchmaking';
-import { initDatabase, saveCompletedGame, getRecentGames, getGame as getDbGame, getStats, getGameCount, saveFeedback } from './database';
+import { initDatabase, saveCompletedGame, getRecentGames, getGame as getDbGame, getStats, getGameCount, saveFeedback, getFeedback, getFeedbackCount } from './database';
 import { ServerToClientEvents, ClientToServerEvents, GameRoom } from '../../shared/types';
 
 const app = express();
@@ -395,6 +395,15 @@ const feedbackLimiter = rateLimit({
   windowMs: 60 * 60 * 1000, // 1 hour
   max: 5,
   message: { error: 'Too many feedback submissions. Please try again later.' },
+});
+
+app.get('/api/feedback', (_req, res) => {
+  const page = parseInt(_req.query.page as string) || 0;
+  const limit = Math.min(parseInt(_req.query.limit as string) || 20, 50);
+  const type = (_req.query.type as string) || undefined;
+  const feedback = getFeedback(limit, page * limit, type);
+  const total = getFeedbackCount(type);
+  res.json({ feedback, total, page, limit });
 });
 
 app.post('/api/feedback', feedbackLimiter, (req, res) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Adds a new page at `/feedback` to view all feedback messages submitted by users through the feedback widget. Previously, feedback was saved to the database but there was no way to read it.

### Changes:
- **Server** (`server/src/database.ts`): Added `getFeedback()` and `getFeedbackCount()` functions with support for pagination and type filtering
- **Server** (`server/src/index.ts`): Added `GET /api/feedback` endpoint with query params for `page`, `limit`, and `type`
- **Client** (`client/src/components/FeedbackMessagesPage.tsx`): New page component with:
  - Card-based UI matching existing design language
  - Filter by feedback type (All / Bug / Feature / Other)
  - Click-to-expand cards showing full message and metadata
  - Pagination support
  - Responsive design (mobile-friendly)
- **Client** (`client/src/App.tsx`): Added `/feedback` route
- **i18n** (`client/src/lib/i18n.tsx`): Added English and Thai translations for the feedback messages page

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Checklist

- [x] Code compiles without errors (`npx tsc --noEmit`)
- [x] Client builds successfully (`npm run build --workspace=client`)
- [x] Tested locally
- [x] No console errors in browser
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-837564bf-73d6-43d8-8410-e27852cb8f74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-837564bf-73d6-43d8-8410-e27852cb8f74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

