### PR TITLE
feat: add right-click arrow drawing, pre-moves, and keyboard move navigation

### DIFF
--- a/client/src/components/Board.tsx
+++ b/client/src/components/Board.tsx
@@ -2,6 +2,12 @@ import { useState, useCallback, useRef } from 'react';
 import type { Board as BoardType, Position, PieceColor, Move } from '@shared/types';
 import PieceSVG from './PieceSVG';
 
+export interface Arrow {
+  from: Position;
+  to: Position;
+  color: string;
+}
+
 interface BoardProps {
   board: BoardType;
   playerColor: PieceColor | null;
@@ -14,6 +20,9 @@ interface BoardProps {
   onSquareClick: (pos: Position) => void;
   onPieceDrop: (from: Position, to: Position) => void;
   disabled?: boolean;
+  premove?: { from: Position; to: Position } | null;
+  arrows?: Arrow[];
+  onArrowsChange?: (arrows: Arrow[]) => void;
 }
 
 export default function Board({
@@ -28,17 +37,32 @@ export default function Board({
   onSquareClick,
   onPieceDrop,
   disabled,
+  premove,
+  arrows: externalArrows,
+  onArrowsChange,
 }: BoardProps) {
   const [dragPiece, setDragPiece] = useState<Position | null>(null);
   const [dragPos, setDragPos] = useState<{ x: number; y: number } | null>(null);
+  const [internalArrows, setInternalArrows] = useState<Arrow[]>([]);
+  const [rightClickStart, setRightClickStart] = useState<Position | null>(null);
+  const [rightDragPos, setRightDragPos] = useState<{ x: number; y: number } | null>(null);
   const boardRef = useRef<HTMLDivElement>(null);
+
+  const arrows = externalArrows ?? internalArrows;
+  const setArrows = useCallback((newArrows: Arrow[]) => {
+    if (onArrowsChange) {
+      onArrowsChange(newArrows);
+    } else {
+      setInternalArrows(newArrows);
+    }
+  }, [onArrowsChange]);
 
   const isFlipped = playerColor === 'black';
 
-  const getDisplayRow = (row: number) => isFlipped ? row : 7 - row;
-  const getDisplayCol = (col: number) => isFlipped ? 7 - col : col;
   const getBoardRow = (displayRow: number) => isFlipped ? displayRow : 7 - displayRow;
   const getBoardCol = (displayCol: number) => isFlipped ? 7 - displayCol : displayCol;
+  const getDisplayRow = (row: number) => isFlipped ? row : 7 - row;
+  const getDisplayCol = (col: number) => isFlipped ? 7 - col : col;
 
   const isLightSquare = (row: number, col: number) => (row + col) % 2 === 0;
 
@@ -60,16 +84,52 @@ export default function Board({
     return isCheck && checkSquare?.row === row && checkSquare?.col === col;
   }, [isCheck, checkSquare]);
 
+  const isPremoveSquare = useCallback((row: number, col: number) => {
+    if (!premove) return false;
+    return (premove.from.row === row && premove.from.col === col) ||
+           (premove.to.row === row && premove.to.col === col);
+  }, [premove]);
+
+  const getSquareFromEvent = (clientX: number, clientY: number): Position | null => {
+    if (!boardRef.current) return null;
+    const rect = boardRef.current.getBoundingClientRect();
+    const squareSize = rect.width / 8;
+    const displayCol = Math.floor((clientX - rect.left) / squareSize);
+    const displayRow = Math.floor((clientY - rect.top) / squareSize);
+    if (displayRow < 0 || displayRow >= 8 || displayCol < 0 || displayCol >= 8) return null;
+    return { row: getBoardRow(displayRow), col: getBoardCol(displayCol) };
+  };
+
   const handleMouseDown = (e: React.MouseEvent, row: number, col: number) => {
+    if (e.button === 2) {
+      setRightClickStart({ row, col });
+      if (boardRef.current) {
+        const rect = boardRef.current.getBoundingClientRect();
+        setRightDragPos({ x: e.clientX - rect.left, y: e.clientY - rect.top });
+      }
+      return;
+    }
+
+    if (e.button !== 0) return;
+
+    if (arrows.length > 0) {
+      setArrows([]);
+    }
+
     if (disabled) return;
     const piece = board[row][col];
-    if (piece && piece.color === playerColor && isMyTurn) {
+    if (piece && piece.color === playerColor) {
       setDragPiece({ row, col });
       onSquareClick({ row, col });
     }
   };
 
   const handleMouseMove = (e: React.MouseEvent) => {
+    if (rightClickStart && boardRef.current) {
+      const rect = boardRef.current.getBoundingClientRect();
+      setRightDragPos({ x: e.clientX - rect.left, y: e.clientY - rect.top });
+    }
+
     if (!dragPiece || !boardRef.current) return;
     const rect = boardRef.current.getBoundingClientRect();
     setDragPos({
@@ -79,6 +139,30 @@ export default function Board({
   };
 
   const handleMouseUp = (e: React.MouseEvent) => {
+    if (e.button === 2 && rightClickStart) {
+      const target = getSquareFromEvent(e.clientX, e.clientY);
+      if (target) {
+        if (target.row === rightClickStart.row && target.col === rightClickStart.col) {
+          setArrows([]);
+        } else {
+          const arrowColor = e.shiftKey ? '#e84040' : '#15781B';
+          const newArrow: Arrow = { from: rightClickStart, to: target, color: arrowColor };
+          const exists = arrows.findIndex(
+            a => a.from.row === newArrow.from.row && a.from.col === newArrow.from.col &&
+                 a.to.row === newArrow.to.row && a.to.col === newArrow.to.col
+          );
+          if (exists >= 0) {
+            setArrows(arrows.filter((_, i) => i !== exists));
+          } else {
+            setArrows([...arrows, newArrow]);
+          }
+        }
+      }
+      setRightClickStart(null);
+      setRightDragPos(null);
+      return;
+    }
+
     if (!dragPiece || !boardRef.current) {
       setDragPiece(null);
       setDragPos(null);
@@ -108,10 +192,14 @@ export default function Board({
     onSquareClick({ row, col });
   };
 
+  const handleContextMenu = (e: React.MouseEvent) => {
+    e.preventDefault();
+  };
+
   const handleTouchStart = (e: React.TouchEvent, row: number, col: number) => {
     if (disabled) return;
     const piece = board[row][col];
-    if (piece && piece.color === playerColor && isMyTurn) {
+    if (piece && piece.color === playerColor) {
       e.preventDefault();
       setDragPiece({ row, col });
       onSquareClick({ row, col });
@@ -166,7 +254,9 @@ export default function Board({
     const light = isLightSquare(boardRow, boardCol);
     let cls = light ? 'board-square-light' : 'board-square-dark';
 
-    if (isSelected(boardRow, boardCol)) {
+    if (isPremoveSquare(boardRow, boardCol)) {
+      cls = light ? 'board-square-premove-light' : 'board-square-premove-dark';
+    } else if (isSelected(boardRow, boardCol)) {
       cls = 'board-square-selected';
     } else if (isLastMove(boardRow, boardCol)) {
       cls = light ? 'board-square-lastmove-light' : 'board-square-lastmove-dark';
@@ -180,6 +270,82 @@ export default function Board({
   };
 
   const squareSize = '12.5%';
+
+  const renderArrowSvg = () => {
+    const allArrows = [...arrows];
+
+    if (rightClickStart && rightDragPos && boardRef.current) {
+      const rect = boardRef.current.getBoundingClientRect();
+      const sqSize = rect.width / 8;
+      const displayCol = Math.floor(rightDragPos.x / sqSize);
+      const displayRow = Math.floor(rightDragPos.y / sqSize);
+      if (displayRow >= 0 && displayRow < 8 && displayCol >= 0 && displayCol < 8) {
+        const target = { row: getBoardRow(displayRow), col: getBoardCol(displayCol) };
+        if (target.row !== rightClickStart.row || target.col !== rightClickStart.col) {
+          allArrows.push({ from: rightClickStart, to: target, color: '#15781B80' });
+        }
+      }
+    }
+
+    if (allArrows.length === 0) return null;
+
+    return (
+      <svg
+        className="absolute inset-0 w-full h-full pointer-events-none"
+        viewBox="0 0 800 800"
+        style={{ zIndex: 50 }}
+      >
+        <defs>
+          {allArrows.map((arrow, i) => (
+            <marker
+              key={`head-${i}`}
+              id={`arrowhead-${i}`}
+              markerWidth="4"
+              markerHeight="4"
+              refX="2.5"
+              refY="2"
+              orient="auto"
+            >
+              <path d="M0,0 L4,2 L0,4 Z" fill={arrow.color} fillOpacity="0.8" />
+            </marker>
+          ))}
+        </defs>
+        {allArrows.map((arrow, i) => {
+          const fromDR = getDisplayRow(arrow.from.row);
+          const fromDC = getDisplayCol(arrow.from.col);
+          const toDR = getDisplayRow(arrow.to.row);
+          const toDC = getDisplayCol(arrow.to.col);
+
+          const x1 = fromDC * 100 + 50;
+          const y1 = fromDR * 100 + 50;
+          const x2 = toDC * 100 + 50;
+          const y2 = toDR * 100 + 50;
+
+          const dx = x2 - x1;
+          const dy = y2 - y1;
+          const dist = Math.sqrt(dx * dx + dy * dy);
+          const shortenBy = 20;
+          const ex = x2 - (dx / dist) * shortenBy;
+          const ey = y2 - (dy / dist) * shortenBy;
+
+          return (
+            <line
+              key={i}
+              x1={x1}
+              y1={y1}
+              x2={ex}
+              y2={ey}
+              stroke={arrow.color}
+              strokeWidth="16"
+              strokeOpacity="0.8"
+              strokeLinecap="round"
+              markerEnd={`url(#arrowhead-${i})`}
+            />
+          );
+        })}
+      </svg>
+    );
+  };
 
   const renderSquares = () => {
     const squares = [];
@@ -206,7 +372,6 @@ export default function Board({
             onTouchStart={(e) => handleTouchStart(e, boardRow, boardCol)}
             onClick={() => handleClick(boardRow, boardCol)}
           >
-            {/* Coordinate labels */}
             {displayCol === 0 && (
               <span className="absolute top-0.5 left-1 text-[10px] font-bold opacity-50 pointer-events-none select-none"
                 style={{ color: isLightSquare(boardRow, boardCol) ? '#b58863' : '#e8c690' }}>
@@ -220,11 +385,9 @@ export default function Board({
               </span>
             )}
 
-            {/* Legal move indicator */}
             {legal && !hasCapture && <div className="legal-dot" />}
             {legal && hasCapture && <div className="legal-capture" />}
 
-            {/* Piece */}
             {piece && !isDragging && (
               <div className="absolute inset-[6%] flex items-center justify-center piece">
                 <PieceSVG type={piece.type} color={piece.color} className="w-full h-full" />
@@ -243,13 +406,20 @@ export default function Board({
       className="relative aspect-square w-full select-none rounded-lg shadow-xl overflow-hidden board-no-select"
       onMouseMove={handleMouseMove}
       onMouseUp={handleMouseUp}
-      onMouseLeave={handleMouseUp}
+      onMouseLeave={(e) => {
+        handleMouseUp(e);
+        setRightClickStart(null);
+        setRightDragPos(null);
+      }}
       onTouchMove={handleTouchMove}
       onTouchEnd={handleTouchEnd}
+      onContextMenu={handleContextMenu}
+      tabIndex={-1}
     >
       {renderSquares()}
 
-      {/* Dragging piece overlay */}
+      {renderArrowSvg()}
+
       {dragPiece && dragPos && board[dragPiece.row][dragPiece.col] && (
         <div
           className="absolute pointer-events-none piece-dragging"

--- a/client/src/components/BotGame.tsx
+++ b/client/src/components/BotGame.tsx
@@ -1,11 +1,12 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { Position, PieceColor, Move, GameState } from '@shared/types';
-import { getLegalMoves, makeMove, createInitialGameState, createInitialBoard } from '@shared/engine';
+import { getLegalMoves, makeMove, createInitialGameState, createInitialBoard, getBoardAtMove } from '@shared/engine';
 import { getBotMove, BotDifficulty } from '@shared/botEngine';
 import { playMoveSound, playCaptureSound, playCheckSound, playGameOverSound } from '../lib/sounds';
 import { useTranslation } from '../lib/i18n';
 import Board from './Board';
+import type { Arrow } from './Board';
 import MoveHistory from './MoveHistory';
 import GameOverModal from './GameOverModal';
 import Header from './Header';
@@ -23,6 +24,11 @@ export default function BotGame() {
   const [gameOverInfo, setGameOverInfo] = useState<{ reason: string; winner: PieceColor | null } | null>(null);
   const [botThinking, setBotThinking] = useState(false);
   const botTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [arrows, setArrows] = useState<Arrow[]>([]);
+  const [viewMoveIndex, setViewMoveIndex] = useState<number | null>(null);
+
+  // Pre-move state for bot games
+  const [premove, setPremove] = useState<{ from: Position; to: Position } | null>(null);
 
   const botColor: PieceColor = playerColor === 'white' ? 'black' : 'white';
   const isPlayerTurn = gameState.turn === playerColor;
@@ -45,6 +51,7 @@ export default function BotGame() {
         const newState = makeMove(gameState, botMoveResult.from, botMoveResult.to);
         if (newState) {
           setGameState(newState);
+          setArrows([]);
           const lastMove = newState.moveHistory[newState.moveHistory.length - 1];
           if (newState.isCheck) playCheckSound();
           else if (lastMove.captured) playCaptureSound();
@@ -53,6 +60,7 @@ export default function BotGame() {
           if (newState.gameOver) {
             const reason = newState.isCheckmate ? 'checkmate' : newState.isStalemate ? 'stalemate' : 'draw';
             setGameOverInfo({ reason, winner: newState.winner });
+            setPremove(null);
             playGameOverSound();
           }
         }
@@ -65,9 +73,90 @@ export default function BotGame() {
     };
   }, [gameState, gameStarted, isPlayerTurn, difficulty]);
 
+  // Auto-execute premove when it becomes player's turn
+  useEffect(() => {
+    if (!premove || !isPlayerTurn || gameState.gameOver || botThinking) return;
+
+    const piece = gameState.board[premove.from.row][premove.from.col];
+    if (piece && piece.color === playerColor) {
+      const legal = getLegalMoves(gameState.board, premove.from);
+      if (legal.some(m => m.row === premove.to.row && m.col === premove.to.col)) {
+        const newState = makeMove(gameState, premove.from, premove.to);
+        if (newState) {
+          setGameState(newState);
+          setArrows([]);
+          const lastMove = newState.moveHistory[newState.moveHistory.length - 1];
+          if (newState.isCheck) playCheckSound();
+          else if (lastMove.captured) playCaptureSound();
+          else playMoveSound();
+          if (newState.gameOver) {
+            const reason = newState.isCheckmate ? 'checkmate' : newState.isStalemate ? 'stalemate' : 'draw';
+            setGameOverInfo({ reason, winner: newState.winner });
+            playGameOverSound();
+          }
+        }
+      }
+    }
+    setPremove(null);
+    setSelectedSquare(null);
+    setLegalMoves([]);
+  }, [isPlayerTurn, premove, gameState, playerColor, botThinking]);
+
+  // Keyboard navigation for move history
+  useEffect(() => {
+    if (!gameState.gameOver || gameState.moveHistory.length === 0) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const moveCount = gameState.moveHistory.length;
+      const current = viewMoveIndex ?? moveCount - 1;
+
+      if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+        e.preventDefault();
+        setViewMoveIndex(Math.max(-1, current - 1));
+      } else if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+        e.preventDefault();
+        setViewMoveIndex(Math.min(moveCount - 1, current + 1));
+      } else if (e.key === 'Home') {
+        e.preventDefault();
+        setViewMoveIndex(-1);
+      } else if (e.key === 'End') {
+        e.preventDefault();
+        setViewMoveIndex(moveCount - 1);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [gameState, viewMoveIndex]);
+
   const handleSquareClick = useCallback((pos: Position) => {
-    if (gameState.gameOver || !isPlayerTurn || botThinking) return;
+    if (gameState.gameOver) return;
     const piece = gameState.board[pos.row][pos.col];
+
+    // Pre-move logic when bot is thinking
+    if (!isPlayerTurn || botThinking) {
+      if (selectedSquare) {
+        if (pos.row !== selectedSquare.row || pos.col !== selectedSquare.col) {
+          const fromPiece = gameState.board[selectedSquare.row][selectedSquare.col];
+          if (fromPiece && fromPiece.color === playerColor) {
+            setPremove({ from: selectedSquare, to: pos });
+            setSelectedSquare(null);
+            setLegalMoves([]);
+            return;
+          }
+        }
+      }
+
+      if (piece && piece.color === playerColor) {
+        setSelectedSquare(pos);
+        setLegalMoves(getLegalMoves(gameState.board, pos));
+        setPremove(null);
+      } else {
+        setSelectedSquare(null);
+        setLegalMoves([]);
+      }
+      return;
+    }
 
     if (selectedSquare) {
       const isLegal = legalMoves.some(m => m.row === pos.row && m.col === pos.col);
@@ -77,6 +166,7 @@ export default function BotGame() {
           setGameState(newState);
           setSelectedSquare(null);
           setLegalMoves([]);
+          setArrows([]);
           const lastMove = newState.moveHistory[newState.moveHistory.length - 1];
           if (newState.isCheck) playCheckSound();
           else if (lastMove.captured) playCaptureSound();
@@ -101,6 +191,17 @@ export default function BotGame() {
   }, [gameState, selectedSquare, legalMoves, isPlayerTurn, botThinking, playerColor]);
 
   const handlePieceDrop = useCallback((from: Position, to: Position) => {
+    // Pre-move via drag when bot is thinking
+    if ((!isPlayerTurn || botThinking) && !gameState.gameOver) {
+      const piece = gameState.board[from.row][from.col];
+      if (piece && piece.color === playerColor) {
+        setPremove({ from, to });
+        setSelectedSquare(null);
+        setLegalMoves([]);
+        return;
+      }
+    }
+
     if (gameState.gameOver || !isPlayerTurn || botThinking) return;
     const piece = gameState.board[from.row][from.col];
     if (!piece || piece.color !== playerColor) return;
@@ -111,6 +212,7 @@ export default function BotGame() {
         setGameState(newState);
         setSelectedSquare(null);
         setLegalMoves([]);
+        setArrows([]);
         const lastMove = newState.moveHistory[newState.moveHistory.length - 1];
         if (newState.isCheck) playCheckSound();
         else if (lastMove.captured) playCaptureSound();
@@ -131,6 +233,9 @@ export default function BotGame() {
     setGameOverInfo(null);
     setBotThinking(false);
     setGameStarted(true);
+    setArrows([]);
+    setViewMoveIndex(null);
+    setPremove(null);
   };
 
   const handleReset = () => {
@@ -141,6 +246,9 @@ export default function BotGame() {
     setLegalMoves([]);
     setGameOverInfo(null);
     setBotThinking(false);
+    setArrows([]);
+    setViewMoveIndex(null);
+    setPremove(null);
   };
 
   const handleResign = () => {
@@ -150,17 +258,21 @@ export default function BotGame() {
       newState.winner = botColor;
       setGameState(newState);
       setGameOverInfo({ reason: 'resignation', winner: botColor });
+      setPremove(null);
       playGameOverSound();
     }
   };
 
   const getLastMove = (): Move | null => {
     if (gameState.moveHistory.length === 0) return null;
-    return gameState.moveHistory[gameState.moveHistory.length - 1];
+    const idx = viewMoveIndex ?? gameState.moveHistory.length - 1;
+    if (idx < 0) return null;
+    return gameState.moveHistory[idx];
   };
 
   const getCheckSquare = (): Position | null => {
     if (!gameState.isCheck) return null;
+    if (viewMoveIndex !== null && viewMoveIndex !== gameState.moveHistory.length - 1) return null;
     for (let row = 0; row < 8; row++) {
       for (let col = 0; col < 8; col++) {
         const piece = gameState.board[row][col];
@@ -171,6 +283,21 @@ export default function BotGame() {
     }
     return null;
   };
+
+  const getDisplayBoard = () => {
+    if (viewMoveIndex === null || viewMoveIndex === gameState.moveHistory.length - 1) {
+      return gameState.board;
+    }
+    if (viewMoveIndex === -1) return createInitialBoard();
+    return getBoardAtMove(createInitialBoard(), gameState.moveHistory, viewMoveIndex);
+  };
+
+  const handleMoveClick = useCallback((index: number) => {
+    if (index === gameState.moveHistory.length - 1 && viewMoveIndex === null) return;
+    setViewMoveIndex(index);
+  }, [gameState.moveHistory.length, viewMoveIndex]);
+
+  const isViewingHistory = viewMoveIndex !== null && viewMoveIndex !== gameState.moveHistory.length - 1;
 
   if (!gameStarted) {
     return (
@@ -260,11 +387,24 @@ export default function BotGame() {
   }
 
   return (
-    <div className="min-h-screen bg-surface flex flex-col">
+    <div className="min-h-screen bg-surface flex flex-col" tabIndex={-1}>
       <Header
         subtitle={`${t('bot.vs_bot')} (${t(difficultyConfig[difficulty].labelKey)})`}
         right={<span>{difficultyConfig[difficulty].emoji}</span>}
       />
+
+      {/* Premove indicator */}
+      {premove && (
+        <div className="bg-blue-900/30 border-b border-blue-500/30 text-center py-1.5 text-xs text-blue-300 flex items-center justify-center gap-2">
+          <span>Pre-move set</span>
+          <button
+            onClick={() => { setPremove(null); setSelectedSquare(null); setLegalMoves([]); }}
+            className="px-2 py-0.5 bg-surface-hover rounded text-xs hover:bg-danger/20 hover:text-danger transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
 
       <main className="flex-1 flex items-center justify-center px-4 py-4">
         <div className="flex flex-col lg:flex-row items-center lg:items-start gap-4 sm:gap-6 w-full max-w-[1100px]">
@@ -282,17 +422,20 @@ export default function BotGame() {
             </div>
 
             <Board
-              board={gameState.board}
+              board={getDisplayBoard()}
               playerColor={playerColor}
               isMyTurn={isPlayerTurn && !botThinking}
-              legalMoves={legalMoves}
-              selectedSquare={selectedSquare}
+              legalMoves={isViewingHistory ? [] : legalMoves}
+              selectedSquare={isViewingHistory ? null : selectedSquare}
               lastMove={getLastMove()}
-              isCheck={gameState.isCheck}
+              isCheck={isViewingHistory ? false : gameState.isCheck}
               checkSquare={getCheckSquare()}
               onSquareClick={handleSquareClick}
               onPieceDrop={handlePieceDrop}
-              disabled={gameState.gameOver || !isPlayerTurn || botThinking}
+              disabled={isViewingHistory || (gameState.gameOver && !isViewingHistory)}
+              premove={premove}
+              arrows={arrows}
+              onArrowsChange={setArrows}
             />
 
             <div className={`rounded-lg px-4 py-2 text-center text-sm font-medium w-full max-w-xs ${
@@ -328,7 +471,18 @@ export default function BotGame() {
               }
             </div>
 
-            <MoveHistory moves={gameState.moveHistory} initialBoard={createInitialBoard()} />
+            <MoveHistory
+              moves={gameState.moveHistory}
+              initialBoard={createInitialBoard()}
+              currentMoveIndex={viewMoveIndex ?? undefined}
+              onMoveClick={gameState.gameOver ? handleMoveClick : undefined}
+            />
+
+            {gameState.gameOver && gameState.moveHistory.length > 0 && (
+              <div className="text-center text-xs text-text-dim">
+                Use arrow keys to navigate moves
+              </div>
+            )}
 
             {!gameState.gameOver && (
               <button

--- a/client/src/components/GamePage.tsx
+++ b/client/src/components/GamePage.tsx
@@ -1,11 +1,12 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import type { Position, PieceColor, ClientGameState, Move } from '@shared/types';
-import { getLegalMoves, createInitialBoard } from '@shared/engine';
+import { getLegalMoves, createInitialBoard, getBoardAtMove } from '@shared/engine';
 import { socket, connectSocket } from '../lib/socket';
 import { playMoveSound, playCaptureSound, playCheckSound, playGameOverSound, playGameStartSound } from '../lib/sounds';
 import { useTranslation } from '../lib/i18n';
 import Board from './Board';
+import type { Arrow } from './Board';
 import Clock from './Clock';
 import MoveHistory from './MoveHistory';
 import GameOverModal from './GameOverModal';
@@ -30,6 +31,16 @@ export default function GamePage() {
   const [error, setError] = useState<string | null>(null);
   const [showGuide, setShowGuide] = useState(false);
   const joinedRef = useRef(false);
+
+  // Pre-move state
+  const [premove, setPremove] = useState<{ from: Position; to: Position } | null>(null);
+
+  // Arrow state
+  const [arrows, setArrows] = useState<Arrow[]>([]);
+
+  // Keyboard navigation state
+  const [viewMoveIndex, setViewMoveIndex] = useState<number | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!gameId) return;
@@ -63,6 +74,7 @@ export default function GamePage() {
       setGameState(gs);
       setSelectedSquare(null);
       setLegalMoves([]);
+      setArrows([]);
       if (gs.isCheck) {
         playCheckSound();
       } else if (move.captured) {
@@ -75,6 +87,7 @@ export default function GamePage() {
     const handleGameOver = ({ reason, winner, gameState: gs }: { reason: string; winner: PieceColor | null; gameState: ClientGameState }) => {
       setGameState(gs);
       setGameOverInfo({ reason, winner });
+      setPremove(null);
       playGameOverSound();
     };
 
@@ -99,13 +112,15 @@ export default function GamePage() {
     };
 
     const handleGameCreated = ({ gameId: newGameId }: { gameId: string }) => {
-      // Rematch - navigate to new game
       joinedRef.current = false;
       setGameState(null);
       setGameOverInfo(null);
       setSelectedSquare(null);
       setLegalMoves([]);
       setDrawOffered(false);
+      setPremove(null);
+      setArrows([]);
+      setViewMoveIndex(null);
       navigate(`/game/${newGameId}`);
     };
 
@@ -148,10 +163,80 @@ export default function GamePage() {
 
   const isMyTurn = gameState?.turn === playerColor && gameState?.status === 'playing';
 
+  // Auto-execute premove when it becomes our turn
+  useEffect(() => {
+    if (!premove || !gameState || !playerColor || !isMyTurn) return;
+
+    const piece = gameState.board[premove.from.row][premove.from.col];
+    if (piece && piece.color === playerColor) {
+      const legal = getLegalMoves(gameState.board, premove.from);
+      if (legal.some(m => m.row === premove.to.row && m.col === premove.to.col)) {
+        socket.emit('make_move', { from: premove.from, to: premove.to });
+      }
+    }
+    setPremove(null);
+    setSelectedSquare(null);
+    setLegalMoves([]);
+  }, [isMyTurn, premove, gameState, playerColor]);
+
+  // Keyboard navigation for move history
+  useEffect(() => {
+    if (!gameState || gameState.moveHistory.length === 0) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (!gameState.gameOver) return;
+
+      const moveCount = gameState.moveHistory.length;
+      const current = viewMoveIndex ?? moveCount - 1;
+
+      if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+        e.preventDefault();
+        setViewMoveIndex(Math.max(-1, current - 1));
+      } else if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+        e.preventDefault();
+        setViewMoveIndex(Math.min(moveCount - 1, current + 1));
+      } else if (e.key === 'Home') {
+        e.preventDefault();
+        setViewMoveIndex(-1);
+      } else if (e.key === 'End') {
+        e.preventDefault();
+        setViewMoveIndex(moveCount - 1);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [gameState, viewMoveIndex]);
+
   const handleSquareClick = useCallback((pos: Position) => {
     if (!gameState || !playerColor || gameState.status !== 'playing') return;
 
     const piece = gameState.board[pos.row][pos.col];
+
+    // Pre-move logic: when it's not our turn, allow setting a premove
+    if (!isMyTurn && !gameState.gameOver) {
+      if (selectedSquare) {
+        if (pos.row !== selectedSquare.row || pos.col !== selectedSquare.col) {
+          const fromPiece = gameState.board[selectedSquare.row][selectedSquare.col];
+          if (fromPiece && fromPiece.color === playerColor) {
+            setPremove({ from: selectedSquare, to: pos });
+            setSelectedSquare(null);
+            setLegalMoves([]);
+            return;
+          }
+        }
+      }
+
+      if (piece && piece.color === playerColor) {
+        setSelectedSquare(pos);
+        setLegalMoves(getLegalMoves(gameState.board, pos));
+        setPremove(null);
+      } else {
+        setSelectedSquare(null);
+        setLegalMoves([]);
+      }
+      return;
+    }
 
     if (selectedSquare) {
       const isLegal = legalMoves.some(m => m.row === pos.row && m.col === pos.col);
@@ -159,6 +244,7 @@ export default function GamePage() {
         socket.emit('make_move', { from: selectedSquare, to: pos });
         setSelectedSquare(null);
         setLegalMoves([]);
+        setArrows([]);
         return;
       }
     }
@@ -173,12 +259,26 @@ export default function GamePage() {
   }, [gameState, playerColor, selectedSquare, legalMoves, isMyTurn]);
 
   const handlePieceDrop = useCallback((from: Position, to: Position) => {
-    if (!gameState || !playerColor || !isMyTurn) return;
+    if (!gameState || !playerColor) return;
+
+    // Pre-move via drag
+    if (!isMyTurn && gameState.status === 'playing' && !gameState.gameOver) {
+      const piece = gameState.board[from.row][from.col];
+      if (piece && piece.color === playerColor) {
+        setPremove({ from, to });
+        setSelectedSquare(null);
+        setLegalMoves([]);
+        return;
+      }
+    }
+
+    if (!isMyTurn) return;
     const legal = getLegalMoves(gameState.board, from);
     if (legal.some(m => m.row === to.row && m.col === to.col)) {
       socket.emit('make_move', { from, to });
       setSelectedSquare(null);
       setLegalMoves([]);
+      setArrows([]);
     }
   }, [gameState, playerColor, isMyTurn]);
 
@@ -215,11 +315,14 @@ export default function GamePage() {
 
   const getLastMove = (): Move | null => {
     if (!gameState || gameState.moveHistory.length === 0) return null;
-    return gameState.moveHistory[gameState.moveHistory.length - 1];
+    const idx = viewMoveIndex ?? gameState.moveHistory.length - 1;
+    if (idx < 0) return null;
+    return gameState.moveHistory[idx];
   };
 
   const getCheckSquare = (): Position | null => {
     if (!gameState?.isCheck) return null;
+    if (viewMoveIndex !== null && viewMoveIndex !== gameState.moveHistory.length - 1) return null;
     const board = gameState.board;
     for (let row = 0; row < 8; row++) {
       for (let col = 0; col < 8; col++) {
@@ -231,6 +334,21 @@ export default function GamePage() {
     }
     return null;
   };
+
+  const getDisplayBoard = () => {
+    if (!gameState) return createInitialBoard();
+    if (viewMoveIndex === null || viewMoveIndex === gameState.moveHistory.length - 1) {
+      return gameState.board;
+    }
+    if (viewMoveIndex === -1) return createInitialBoard();
+    return getBoardAtMove(createInitialBoard(), gameState.moveHistory, viewMoveIndex);
+  };
+
+  const handleMoveClick = useCallback((index: number) => {
+    if (!gameState) return;
+    if (index === gameState.moveHistory.length - 1 && viewMoveIndex === null) return;
+    setViewMoveIndex(index);
+  }, [gameState, viewMoveIndex]);
 
   // Waiting room
   if (gameState && gameState.status === 'waiting') {
@@ -307,9 +425,10 @@ export default function GamePage() {
   }
 
   const opponentColor: PieceColor = playerColor === 'white' ? 'black' : 'white';
+  const isViewingHistory = viewMoveIndex !== null && viewMoveIndex !== gameState.moveHistory.length - 1;
 
   return (
-    <div className="min-h-screen bg-surface flex flex-col">
+    <div ref={containerRef} className="min-h-screen bg-surface flex flex-col" tabIndex={-1}>
       <ConnectionStatus />
 
       {/* Compact Header for playing state */}
@@ -359,6 +478,19 @@ export default function GamePage() {
         </div>
       )}
 
+      {/* Premove indicator */}
+      {premove && (
+        <div className="bg-blue-900/30 border-b border-blue-500/30 text-center py-1.5 text-xs text-blue-300 flex items-center justify-center gap-2">
+          <span>Pre-move set</span>
+          <button
+            onClick={() => { setPremove(null); setSelectedSquare(null); setLegalMoves([]); }}
+            className="px-2 py-0.5 bg-surface-hover rounded text-xs hover:bg-danger/20 hover:text-danger transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+
       {/* Main Game Area */}
       <main className="flex-1 flex items-center justify-center p-4 sm:p-6 py-4">
         <div className="flex flex-col lg:flex-row items-center lg:items-start gap-6 w-full max-w-[1100px]">
@@ -374,17 +506,20 @@ export default function GamePage() {
 
             {/* Board */}
             <Board
-              board={gameState.board}
+              board={getDisplayBoard()}
               playerColor={playerColor}
               isMyTurn={isMyTurn}
-              legalMoves={legalMoves}
-              selectedSquare={selectedSquare}
+              legalMoves={isViewingHistory ? [] : legalMoves}
+              selectedSquare={isViewingHistory ? null : selectedSquare}
               lastMove={getLastMove()}
-              isCheck={gameState.isCheck}
+              isCheck={isViewingHistory ? false : gameState.isCheck}
               checkSquare={getCheckSquare()}
               onSquareClick={handleSquareClick}
               onPieceDrop={handlePieceDrop}
-              disabled={!isMyTurn || gameState.gameOver}
+              disabled={isViewingHistory || (gameState.gameOver && !isViewingHistory)}
+              premove={premove}
+              arrows={arrows}
+              onArrowsChange={setArrows}
             />
 
             {/* Player Clock */}
@@ -415,7 +550,19 @@ export default function GamePage() {
             </div>
 
             {/* Move History */}
-            <MoveHistory moves={gameState.moveHistory} initialBoard={createInitialBoard()} />
+            <MoveHistory
+              moves={gameState.moveHistory}
+              initialBoard={createInitialBoard()}
+              currentMoveIndex={viewMoveIndex ?? undefined}
+              onMoveClick={gameState.gameOver ? handleMoveClick : undefined}
+            />
+
+            {/* Keyboard nav hint */}
+            {gameState.gameOver && gameState.moveHistory.length > 0 && (
+              <div className="text-center text-xs text-text-dim">
+                Use arrow keys to navigate moves
+              </div>
+            )}
 
             {/* Game Controls */}
             {!gameState.gameOver && gameState.status === 'playing' && (

--- a/client/src/components/LocalGame.tsx
+++ b/client/src/components/LocalGame.tsx
@@ -1,10 +1,11 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { Position, PieceColor, Move, GameState } from '@shared/types';
-import { getLegalMoves, makeMove, createInitialGameState, createInitialBoard } from '@shared/engine';
+import { getLegalMoves, makeMove, createInitialGameState, createInitialBoard, getBoardAtMove } from '@shared/engine';
 import { playMoveSound, playCaptureSound, playCheckSound, playGameOverSound } from '../lib/sounds';
 import { useTranslation } from '../lib/i18n';
 import Board from './Board';
+import type { Arrow } from './Board';
 import MoveHistory from './MoveHistory';
 import GameOverModal from './GameOverModal';
 import Header from './Header';
@@ -17,6 +18,34 @@ export default function LocalGame() {
   const [legalMoves, setLegalMoves] = useState<Position[]>([]);
   const [viewAs, setViewAs] = useState<PieceColor>('white');
   const [gameOverInfo, setGameOverInfo] = useState<{ reason: string; winner: PieceColor | null } | null>(null);
+  const [arrows, setArrows] = useState<Arrow[]>([]);
+  const [viewMoveIndex, setViewMoveIndex] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!gameState.gameOver || gameState.moveHistory.length === 0) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const moveCount = gameState.moveHistory.length;
+      const current = viewMoveIndex ?? moveCount - 1;
+
+      if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+        e.preventDefault();
+        setViewMoveIndex(Math.max(-1, current - 1));
+      } else if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+        e.preventDefault();
+        setViewMoveIndex(Math.min(moveCount - 1, current + 1));
+      } else if (e.key === 'Home') {
+        e.preventDefault();
+        setViewMoveIndex(-1);
+      } else if (e.key === 'End') {
+        e.preventDefault();
+        setViewMoveIndex(moveCount - 1);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [gameState, viewMoveIndex]);
 
   const handleSquareClick = useCallback((pos: Position) => {
     if (gameState.gameOver) return;
@@ -30,6 +59,7 @@ export default function LocalGame() {
           setGameState(newState);
           setSelectedSquare(null);
           setLegalMoves([]);
+          setArrows([]);
           const lastMove = newState.moveHistory[newState.moveHistory.length - 1];
           if (newState.isCheck) playCheckSound();
           else if (lastMove.captured) playCaptureSound();
@@ -64,6 +94,7 @@ export default function LocalGame() {
         setGameState(newState);
         setSelectedSquare(null);
         setLegalMoves([]);
+        setArrows([]);
         const lastMove = newState.moveHistory[newState.moveHistory.length - 1];
         if (newState.isCheck) playCheckSound();
         else if (lastMove.captured) playCaptureSound();
@@ -82,15 +113,20 @@ export default function LocalGame() {
     setSelectedSquare(null);
     setLegalMoves([]);
     setGameOverInfo(null);
+    setArrows([]);
+    setViewMoveIndex(null);
   };
 
   const getLastMove = (): Move | null => {
     if (gameState.moveHistory.length === 0) return null;
-    return gameState.moveHistory[gameState.moveHistory.length - 1];
+    const idx = viewMoveIndex ?? gameState.moveHistory.length - 1;
+    if (idx < 0) return null;
+    return gameState.moveHistory[idx];
   };
 
   const getCheckSquare = (): Position | null => {
     if (!gameState.isCheck) return null;
+    if (viewMoveIndex !== null && viewMoveIndex !== gameState.moveHistory.length - 1) return null;
     for (let row = 0; row < 8; row++) {
       for (let col = 0; col < 8; col++) {
         const piece = gameState.board[row][col];
@@ -102,10 +138,25 @@ export default function LocalGame() {
     return null;
   };
 
+  const getDisplayBoard = () => {
+    if (viewMoveIndex === null || viewMoveIndex === gameState.moveHistory.length - 1) {
+      return gameState.board;
+    }
+    if (viewMoveIndex === -1) return createInitialBoard();
+    return getBoardAtMove(createInitialBoard(), gameState.moveHistory, viewMoveIndex);
+  };
+
+  const handleMoveClick = useCallback((index: number) => {
+    if (index === gameState.moveHistory.length - 1 && viewMoveIndex === null) return;
+    setViewMoveIndex(index);
+  }, [gameState.moveHistory.length, viewMoveIndex]);
+
   const colorName = (c: PieceColor) => t(c === 'white' ? 'common.white' : 'common.black');
 
+  const isViewingHistory = viewMoveIndex !== null && viewMoveIndex !== gameState.moveHistory.length - 1;
+
   return (
-    <div className="min-h-screen bg-surface flex flex-col">
+    <div className="min-h-screen bg-surface flex flex-col" tabIndex={-1}>
       <Header subtitle={t('local.title')} />
 
       <main className="flex-1 flex items-center justify-center px-4 py-4">
@@ -128,17 +179,19 @@ export default function LocalGame() {
             </div>
 
             <Board
-              board={gameState.board}
+              board={getDisplayBoard()}
               playerColor={viewAs}
-              isMyTurn={true}
-              legalMoves={legalMoves}
-              selectedSquare={selectedSquare}
+              isMyTurn={!isViewingHistory}
+              legalMoves={isViewingHistory ? [] : legalMoves}
+              selectedSquare={isViewingHistory ? null : selectedSquare}
               lastMove={getLastMove()}
-              isCheck={gameState.isCheck}
+              isCheck={isViewingHistory ? false : gameState.isCheck}
               checkSquare={getCheckSquare()}
               onSquareClick={handleSquareClick}
               onPieceDrop={handlePieceDrop}
-              disabled={gameState.gameOver}
+              disabled={gameState.gameOver || isViewingHistory}
+              arrows={arrows}
+              onArrowsChange={setArrows}
             />
 
             <div className={`
@@ -158,7 +211,18 @@ export default function LocalGame() {
           </div>
 
           <div className="flex flex-col gap-3 lg:w-72 w-full max-w-[720px]">
-            <MoveHistory moves={gameState.moveHistory} initialBoard={createInitialBoard()} />
+            <MoveHistory
+              moves={gameState.moveHistory}
+              initialBoard={createInitialBoard()}
+              currentMoveIndex={viewMoveIndex ?? undefined}
+              onMoveClick={gameState.gameOver ? handleMoveClick : undefined}
+            />
+
+            {gameState.gameOver && gameState.moveHistory.length > 0 && (
+              <div className="text-center text-xs text-text-dim">
+                Use arrow keys to navigate moves
+              </div>
+            )}
 
             <button
               onClick={handleReset}

--- a/client/src/components/MoveHistory.tsx
+++ b/client/src/components/MoveHistory.tsx
@@ -1,3 +1,4 @@
+import { useRef, useEffect } from 'react';
 import type { Move, Board } from '@shared/types';
 import { posToAlgebraic } from '@shared/engine';
 import { useTranslation } from '../lib/i18n';
@@ -5,11 +6,19 @@ import { useTranslation } from '../lib/i18n';
 interface MoveHistoryProps {
   moves: Move[];
   initialBoard: Board;
+  currentMoveIndex?: number;
+  onMoveClick?: (index: number) => void;
 }
 
-export default function MoveHistory({ moves }: MoveHistoryProps) {
+export default function MoveHistory({ moves, currentMoveIndex, onMoveClick }: MoveHistoryProps) {
   const { t } = useTranslation();
-  const movePairs: { num: number; white: string; black?: string }[] = [];
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const activeMoveRef = useRef<HTMLSpanElement>(null);
+
+  const isNavigating = currentMoveIndex !== undefined && currentMoveIndex !== moves.length - 1;
+  const activeIndex = currentMoveIndex ?? moves.length - 1;
+
+  const movePairs: { num: number; white: string; black?: string; whiteIdx: number; blackIdx: number }[] = [];
 
   for (let i = 0; i < moves.length; i += 2) {
     const whiteMove = moves[i];
@@ -26,26 +35,48 @@ export default function MoveHistory({ moves }: MoveHistoryProps) {
       num: Math.floor(i / 2) + 1,
       white: formatMove(whiteMove),
       black: blackMove ? formatMove(blackMove) : undefined,
+      whiteIdx: i,
+      blackIdx: i + 1,
     });
   }
+
+  useEffect(() => {
+    if (activeMoveRef.current && scrollRef.current) {
+      activeMoveRef.current.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    }
+  }, [activeIndex]);
 
   return (
     <div className="bg-surface-alt rounded-lg border border-surface-hover overflow-hidden">
       <div className="px-3 py-2 border-b border-surface-hover">
         <h3 className="text-sm font-semibold text-text-bright">{t('moves.title')}</h3>
       </div>
-      <div className="max-h-[300px] overflow-y-auto p-1">
+      <div ref={scrollRef} className="max-h-[300px] overflow-y-auto p-1">
         {movePairs.length === 0 ? (
           <div className="text-text-dim text-sm text-center py-4">{t('moves.empty')}</div>
         ) : (
           <div className="grid grid-cols-[auto_1fr_1fr] gap-x-2 text-sm">
-            {movePairs.map(({ num, white, black }) => (
+            {movePairs.map(({ num, white, black, whiteIdx, blackIdx }) => (
               <div key={num} className="contents">
                 <span className="text-text-dim px-2 py-0.5 text-right">{num}.</span>
-                <span className="text-text-bright px-2 py-0.5 rounded hover:bg-surface-hover cursor-default font-mono">
+                <span
+                  ref={activeIndex === whiteIdx ? activeMoveRef : undefined}
+                  className={`text-text-bright px-2 py-0.5 font-mono ${
+                    activeIndex === whiteIdx ? 'move-active' : 'move-clickable'
+                  }`}
+                  onClick={() => onMoveClick?.(whiteIdx)}
+                >
                   {white}
                 </span>
-                <span className="text-text-bright px-2 py-0.5 rounded hover:bg-surface-hover cursor-default font-mono">
+                <span
+                  ref={activeIndex === blackIdx ? activeMoveRef : undefined}
+                  className={`text-text-bright px-2 py-0.5 font-mono ${
+                    black
+                      ? activeIndex === blackIdx ? 'move-active' : 'move-clickable'
+                      : ''
+                  }`}
+                  onClick={() => black && onMoveClick?.(blackIdx)}
+                >
                   {black || ''}
                 </span>
               </div>
@@ -53,6 +84,39 @@ export default function MoveHistory({ moves }: MoveHistoryProps) {
           </div>
         )}
       </div>
+
+      {onMoveClick && moves.length > 0 && (
+        <div className="flex items-center justify-center gap-1 px-3 py-2 border-t border-surface-hover">
+          <button
+            onClick={() => onMoveClick(-1)}
+            className="px-2.5 py-1 text-xs rounded bg-surface hover:bg-surface-hover text-text-dim hover:text-text-bright transition-colors"
+            title="First position"
+          >
+            ⏮
+          </button>
+          <button
+            onClick={() => onMoveClick(Math.max(-1, activeIndex - 1))}
+            className="px-2.5 py-1 text-xs rounded bg-surface hover:bg-surface-hover text-text-dim hover:text-text-bright transition-colors"
+            title="Previous move"
+          >
+            ◀
+          </button>
+          <button
+            onClick={() => onMoveClick(Math.min(moves.length - 1, activeIndex + 1))}
+            className="px-2.5 py-1 text-xs rounded bg-surface hover:bg-surface-hover text-text-dim hover:text-text-bright transition-colors"
+            title="Next move"
+          >
+            ▶
+          </button>
+          <button
+            onClick={() => onMoveClick(moves.length - 1)}
+            className="px-2.5 py-1 text-xs rounded bg-surface hover:bg-surface-hover text-text-dim hover:text-text-bright transition-colors"
+            title="Last move"
+          >
+            ⏭
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -120,6 +120,29 @@
   ) !important;
 }
 
+/* Pre-move square highlights */
+.board-square-premove-light {
+  background-color: oklch(0.65 0.14 250) !important;
+}
+.board-square-premove-dark {
+  background-color: oklch(0.50 0.14 250) !important;
+}
+
+/* Active move highlight in MoveHistory */
+.move-active {
+  background-color: var(--color-primary);
+  color: white;
+  border-radius: 4px;
+}
+.move-clickable {
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background-color 0.1s ease;
+}
+.move-clickable:hover {
+  background-color: var(--color-surface-hover);
+}
+
 /* ─── Legal-move indicators ──────────────────────────────────────── */
 
 .legal-dot {

--- a/shared/engine.ts
+++ b/shared/engine.ts
@@ -323,6 +323,21 @@ export function moveToNotation(move: Move, piece: Piece): string {
   return `${prefix}${capture}${dest}${promo}`;
 }
 
+export function getBoardAtMove(initialBoard: Board, moves: Move[], moveIndex: number): Board {
+  let board = cloneBoard(initialBoard);
+  const count = Math.min(moveIndex + 1, moves.length);
+  for (let i = 0; i < count; i++) {
+    const move = moves[i];
+    board[move.to.row][move.to.col] = board[move.from.row][move.from.col];
+    board[move.from.row][move.from.col] = null;
+    if (move.promoted) {
+      const piece = board[move.to.row][move.to.col]!;
+      board[move.to.row][move.to.col] = { type: 'PM', color: piece.color };
+    }
+  }
+  return board;
+}
+
 export function getAllPieces(board: Board, color: PieceColor): { piece: Piece; pos: Position }[] {
   const pieces: { piece: Piece; pos: Position }[] = [];
   for (let row = 0; row < 8; row++) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Adds three interactive features inspired by lichess and chess.com:

### 1. Right-Click Arrow Drawing
- Right-click and drag on the board to draw arrows between squares
- Default arrow color is green; hold **Shift** for red arrows
- Right-clicking the same square clears all arrows
- Left-clicking anywhere on the board clears arrows
- Arrows are rendered as an SVG overlay with proper board orientation support
- Works across all game modes (online, local, bot)

### 2. Pre-Move Support
- When it's not your turn, you can select your own piece and choose a target square to queue a pre-move
- Supports both click-to-select and drag-and-drop for setting pre-moves
- Pre-move source and destination squares are highlighted in blue
- When your turn arrives, the pre-move is auto-executed if it's still legal
- A banner shows at the top with a cancel button when a pre-move is active
- Available in online games (GamePage) and bot games (BotGame)

### 3. Keyboard Navigation After Game Ends
- After a game finishes, use **Arrow Left/Up** and **Arrow Right/Down** keys to step through move history
- **Home** jumps to the starting position, **End** jumps to the final position
- Board is reconstructed at each move index using the new `getBoardAtMove()` engine utility
- MoveHistory component now shows clickable moves with the active move highlighted
- Navigation buttons (first/prev/next/last) appear below the move list when game is over
- Hint text displayed when keyboard navigation is available
- Works across all game modes (online, local, bot)

### Technical Changes
- **Board.tsx**: Added arrow drawing state, right-click event handling, SVG arrow rendering, premove square highlighting, context menu prevention
- **GamePage.tsx**: Added premove state, premove auto-execution effect, keyboard navigation effect, history board reconstruction
- **BotGame.tsx**: Same premove and keyboard navigation support as GamePage
- **LocalGame.tsx**: Arrow drawing and keyboard navigation support
- **MoveHistory.tsx**: Added `currentMoveIndex` and `onMoveClick` props, clickable moves, active move highlighting, navigation buttons, auto-scroll to active move
- **shared/engine.ts**: Added `getBoardAtMove()` utility for replaying moves from initial board
- **index.css**: Added premove square highlight colors (blue tint), active move and clickable move styles

## Type of Change

- [x] New feature

## Checklist

- [x] Code compiles without errors (`npx tsc --noEmit`)
- [x] Client builds successfully (`npm run build --workspace=client`)
- [ ] Tested locally
- [ ] No console errors in browser
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a149b1f-a759-4acc-8486-0f7bdcb94379"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a149b1f-a759-4acc-8486-0f7bdcb94379"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

