### PR TITLE
Add SEO and AEO foundations

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -16,11 +16,18 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&family=Noto+Sans+Thai:wght@400;500;600;700&display=swap" rel="stylesheet" />
 
-    <title>ThaiChess — The Ancient Art of Chess</title>
-    <meta name="description" content="Play ThaiChess online with friends for free. Inspired by Lichess." />
-    <meta property="og:title" content="ThaiChess — The Ancient Art of Chess" />
-    <meta property="og:description" content="Free ThaiChess platform. Play with friends online. No registration needed." />
+    <title>Play ThaiChess Online Free | Makruk with Friends, Bot, and Puzzles</title>
+    <meta name="description" content="Play ThaiChess online for free. Challenge friends, practice against a bot, solve Makruk puzzles, and learn the traditional Thai chess game in your browser." />
+    <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1" />
+    <meta name="keywords" content="ThaiChess, Makruk, Thai chess, play ThaiChess online, Makruk puzzles, Thai chess strategy" />
+    <link rel="canonical" href="https://thaichess.dev/" />
+    <meta property="og:title" content="Play ThaiChess Online Free | Makruk with Friends, Bot, and Puzzles" />
+    <meta property="og:description" content="Play ThaiChess online for free. Challenge friends, practice against a bot, solve Makruk puzzles, and learn the traditional Thai chess game in your browser." />
     <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://thaichess.dev/" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Play ThaiChess Online Free | Makruk with Friends, Bot, and Puzzles" />
+    <meta name="twitter:description" content="Play ThaiChess online for free. Challenge friends, practice against a bot, solve Makruk puzzles, and learn the traditional Thai chess game in your browser." />
   </head>
   <body>
     <div id="root"></div>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import HomePage from './components/HomePage';
 import FeedbackWidget from './components/FeedbackWidget';
+import { SeoHeadManager } from './lib/seo';
 
 // Lazy load route components for code splitting
 const GamePage = lazy(() => import('./components/GamePage'));
@@ -32,6 +33,7 @@ function RouteFallback() {
 export default function App() {
   return (
     <div className="min-h-screen bg-surface">
+      <SeoHeadManager />
       <a href="#main-content" className="skip-to-content">
         Skip to main content
       </a>

--- a/client/src/lib/seo.tsx
+++ b/client/src/lib/seo.tsx
@@ -1,0 +1,89 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { getPublicSeoRoute } from '@shared/seo';
+
+const META_KEY = 'data-seo-managed';
+
+function getBaseUrl(): string {
+  if (typeof window !== 'undefined' && window.location.origin) {
+    return window.location.origin;
+  }
+
+  return 'https://thaichess.dev';
+}
+
+function upsertMeta(name: string, content: string, attribute: 'name' | 'property' = 'name') {
+  const selector = `meta[${attribute}="${name}"][${META_KEY}="true"]`;
+  let tag = document.head.querySelector(selector) as HTMLMetaElement | null;
+
+  if (!tag) {
+    tag = document.createElement('meta');
+    tag.setAttribute(attribute, name);
+    tag.setAttribute(META_KEY, 'true');
+    document.head.appendChild(tag);
+  }
+
+  tag.content = content;
+}
+
+function upsertLink(rel: string, href: string) {
+  const selector = `link[rel="${rel}"][${META_KEY}="true"]`;
+  let tag = document.head.querySelector(selector) as HTMLLinkElement | null;
+
+  if (!tag) {
+    tag = document.createElement('link');
+    tag.rel = rel;
+    tag.setAttribute(META_KEY, 'true');
+    document.head.appendChild(tag);
+  }
+
+  tag.href = href;
+}
+
+function upsertStructuredData(json: string) {
+  const selector = `script[type="application/ld+json"][${META_KEY}="true"]`;
+  const existing = Array.from(document.head.querySelectorAll(selector));
+
+  for (const node of existing) {
+    node.remove();
+  }
+
+  const script = document.createElement('script');
+  script.type = 'application/ld+json';
+  script.setAttribute(META_KEY, 'true');
+  script.textContent = json;
+  document.head.appendChild(script);
+}
+
+export function SeoHeadManager() {
+  const location = useLocation();
+
+  useEffect(() => {
+    const baseUrl = getBaseUrl();
+    const seo = getPublicSeoRoute(location.pathname, baseUrl);
+    const canonicalUrl = new URL(seo.path, `${baseUrl}/`).toString();
+
+    document.title = seo.title;
+    upsertMeta('description', seo.description);
+    upsertMeta('robots', seo.robots ?? 'index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1');
+    upsertMeta('keywords', seo.keywords?.join(', ') ?? '');
+    upsertMeta('og:title', seo.title, 'property');
+    upsertMeta('og:description', seo.description, 'property');
+    upsertMeta('og:type', seo.type ?? 'website', 'property');
+    upsertMeta('og:url', canonicalUrl, 'property');
+    upsertMeta('twitter:card', 'summary', 'name');
+    upsertMeta('twitter:title', seo.title, 'name');
+    upsertMeta('twitter:description', seo.description, 'name');
+    upsertLink('canonical', canonicalUrl);
+
+    if (seo.structuredData?.length) {
+      upsertStructuredData(JSON.stringify(seo.structuredData.length === 1 ? seo.structuredData[0] : seo.structuredData));
+      return;
+    }
+
+    const existing = document.head.querySelector(`script[type="application/ld+json"][${META_KEY}="true"]`);
+    existing?.remove();
+  }, [location.pathname]);
+
+  return null;
+}

--- a/render.yaml
+++ b/render.yaml
@@ -13,6 +13,8 @@ services:
         value: production
       - key: NODE_VERSION
         value: "22"
+      - key: SITE_URL
+        value: https://thaichess.dev
     # SQLite: default DATA_DIR is ./data at repo root — ephemeral on free web (resets on redeploy).
     # For persistent DB, add a disk in the Render dashboard and set DATA_DIR to the mount path, e.g.:
     # disk:

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -2,12 +2,14 @@ import express from 'express';
 import { createServer } from 'http';
 import { Server, type Socket } from 'socket.io';
 import cors from 'cors';
+import fs from 'fs';
 import path from 'path';
 import rateLimit from 'express-rate-limit';
 import { GameManager } from './gameManager';
 import { MatchmakingQueue, QueueEntry } from './matchmaking';
 import { initDatabase, saveCompletedGame, getRecentGames, getGame as getDbGame, getStats, getGameCount, saveFeedback, getFeedbackCount, getFeedbackForAdmin, moderateFeedback, updateUsername } from './database';
 import { ServerToClientEvents, ClientToServerEvents, GameRoom } from '../../shared/types';
+import { getIndexablePaths, getPublicSeoRoute } from '../../shared/seo';
 import { logError, logInfo, logWarn } from './logger';
 import { MonitoringStore } from './monitoring';
 import { getSocketIp, isValidBoolean, isValidGameId, isValidPosition, isValidTimeControl, SocketRateLimiter } from './security';
@@ -55,6 +57,66 @@ app.use((req, _res, next) => {
 // Serve static files in production (__dirname = server/dist/server/src when compiled)
 const clientDist = path.join(__dirname, '../../../../client/dist');
 app.use(express.static(clientDist));
+
+function getSiteUrl(req?: express.Request): string {
+  const configuredUrl = process.env.SITE_URL || process.env.PUBLIC_SITE_URL || process.env.APP_URL || process.env.RENDER_EXTERNAL_URL;
+  if (configuredUrl) {
+    return configuredUrl.replace(/\/+$/, '');
+  }
+
+  if (req) {
+    return `${req.protocol}://${req.get('host')}`;
+  }
+
+  return 'https://thaichess.dev';
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function upsertHeadTag(html: string, pattern: RegExp, replacement: string): string {
+  if (pattern.test(html)) {
+    return html.replace(pattern, replacement);
+  }
+
+  return html.replace('</head>', `  ${replacement}\n  </head>`);
+}
+
+function renderSeoHtml(template: string, pathname: string, baseUrl: string): string {
+  const seo = getPublicSeoRoute(pathname, baseUrl);
+  const canonicalUrl = new URL(seo.path, `${baseUrl}/`).toString();
+  const robots = seo.robots ?? 'index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1';
+  const keywords = seo.keywords?.join(', ');
+  const structuredData = seo.structuredData?.length
+    ? JSON.stringify(seo.structuredData.length === 1 ? seo.structuredData[0] : seo.structuredData).replace(/</g, '\\u003c')
+    : null;
+
+  let html = template;
+  html = html.replace(/<title>.*?<\/title>/s, `<title>${escapeHtml(seo.title)}</title>`);
+  html = upsertHeadTag(html, /<meta\s+name="description"\s+content="[^"]*"\s*\/?>/i, `<meta name="description" content="${escapeHtml(seo.description)}" />`);
+  html = upsertHeadTag(html, /<meta\s+name="robots"\s+content="[^"]*"\s*\/?>/i, `<meta name="robots" content="${escapeHtml(robots)}" />`);
+  html = upsertHeadTag(html, /<meta\s+name="keywords"\s+content="[^"]*"\s*\/?>/i, `<meta name="keywords" content="${escapeHtml(keywords ?? '')}" />`);
+  html = upsertHeadTag(html, /<link\s+rel="canonical"\s+href="[^"]*"\s*\/?>/i, `<link rel="canonical" href="${escapeHtml(canonicalUrl)}" />`);
+  html = upsertHeadTag(html, /<meta\s+property="og:title"\s+content="[^"]*"\s*\/?>/i, `<meta property="og:title" content="${escapeHtml(seo.title)}" />`);
+  html = upsertHeadTag(html, /<meta\s+property="og:description"\s+content="[^"]*"\s*\/?>/i, `<meta property="og:description" content="${escapeHtml(seo.description)}" />`);
+  html = upsertHeadTag(html, /<meta\s+property="og:type"\s+content="[^"]*"\s*\/?>/i, `<meta property="og:type" content="${escapeHtml(seo.type ?? 'website')}" />`);
+  html = upsertHeadTag(html, /<meta\s+property="og:url"\s+content="[^"]*"\s*\/?>/i, `<meta property="og:url" content="${escapeHtml(canonicalUrl)}" />`);
+  html = upsertHeadTag(html, /<meta\s+name="twitter:card"\s+content="[^"]*"\s*\/?>/i, '<meta name="twitter:card" content="summary" />');
+  html = upsertHeadTag(html, /<meta\s+name="twitter:title"\s+content="[^"]*"\s*\/?>/i, `<meta name="twitter:title" content="${escapeHtml(seo.title)}" />`);
+  html = upsertHeadTag(html, /<meta\s+name="twitter:description"\s+content="[^"]*"\s*\/?>/i, `<meta name="twitter:description" content="${escapeHtml(seo.description)}" />`);
+
+  html = html.replace(/\s*<script[^>]*data-seo-server="true"[^>]*>.*?<\/script>/gs, '');
+  if (structuredData) {
+    html = html.replace('</head>', `  <script type="application/ld+json" data-seo-server="true">${structuredData}</script>\n  </head>`);
+  }
+
+  return html;
+}
 
 // Initialize database
 const gameManager = new GameManager();
@@ -352,9 +414,57 @@ app.delete('/api/feedback/:id', async (req, res) => {
   res.json({ ok: true });
 });
 
+app.get('/robots.txt', (req, res) => {
+  const siteUrl = getSiteUrl(req);
+  res.type('text/plain').send([
+    'User-agent: *',
+    'Allow: /',
+    'Disallow: /account',
+    'Disallow: /analysis',
+    'Disallow: /feedback',
+    'Disallow: /game',
+    'Disallow: /login',
+    '',
+    `Sitemap: ${siteUrl}/sitemap.xml`,
+  ].join('\n'));
+});
+
+app.get('/sitemap.xml', (req, res) => {
+  const siteUrl = getSiteUrl(req);
+  const lastmod = new Date().toISOString().slice(0, 10);
+  const urls = getIndexablePaths()
+    .map((pathname) => [
+      '  <url>',
+      `    <loc>${siteUrl}${pathname}</loc>`,
+      `    <lastmod>${lastmod}</lastmod>`,
+      pathname === '/' ? '    <priority>1.0</priority>' : '    <priority>0.8</priority>',
+      '  </url>',
+    ].join('\n'))
+    .join('\n');
+
+  res.type('application/xml').send([
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    urls,
+    '</urlset>',
+  ].join('\n'));
+});
+
 // SPA fallback (must be last)
-app.get('*', (_req, res) => {
-  res.sendFile(path.join(clientDist, 'index.html'));
+app.get('*', (req, res) => {
+  const indexPath = path.join(clientDist, 'index.html');
+
+  try {
+    const template = fs.readFileSync(indexPath, 'utf8');
+    const html = renderSeoHtml(template, req.path, getSiteUrl(req));
+    res.type('html').send(html);
+  } catch (error) {
+    logWarn('spa_fallback_template_read_failed', {
+      path: indexPath,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    res.sendFile(indexPath);
+  }
 });
 
 const PORT = process.env.PORT || 3000;

--- a/shared/seo.ts
+++ b/shared/seo.ts
@@ -1,0 +1,247 @@
+import { PUZZLES } from './puzzles';
+
+export interface SeoRouteData {
+  title: string;
+  description: string;
+  path: string;
+  keywords?: string[];
+  robots?: string;
+  type?: 'website' | 'article';
+  structuredData?: Record<string, unknown>[];
+}
+
+const defaultKeywords = [
+  'ThaiChess',
+  'Makruk',
+  'Thai chess',
+  'play ThaiChess online',
+  'Makruk puzzles',
+  'Thai chess strategy',
+];
+
+function buildWebsiteSchema(baseUrl: string): Record<string, unknown> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name: 'ThaiChess',
+    alternateName: 'Makruk Thai Chess',
+    url: baseUrl,
+    description: 'Play ThaiChess online for free with friends, bots, and puzzles.',
+    inLanguage: ['en', 'th'],
+  };
+}
+
+function buildWebApplicationSchema(baseUrl: string): Record<string, unknown> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'ThaiChess',
+    applicationCategory: 'GameApplication',
+    operatingSystem: 'Web',
+    url: baseUrl,
+    browserRequirements: 'Requires JavaScript and a modern browser.',
+    offers: {
+      '@type': 'Offer',
+      price: '0',
+      priceCurrency: 'USD',
+    },
+    inLanguage: ['en', 'th'],
+    keywords: defaultKeywords.join(', '),
+  };
+}
+
+function buildHomeFaqSchema(): Record<string, unknown> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: [
+      {
+        '@type': 'Question',
+        name: 'What is ThaiChess?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'ThaiChess, also called Makruk, is the traditional chess variant of Thailand with its own pieces, openings, and endgame ideas.',
+        },
+      },
+      {
+        '@type': 'Question',
+        name: 'Can I play ThaiChess online for free?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'Yes. ThaiChess lets you play online for free in your browser.',
+        },
+      },
+      {
+        '@type': 'Question',
+        name: 'Can I play ThaiChess with friends or against a bot?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'Yes. You can create private games for friends, play local games, solve puzzles, and practice against a bot.',
+        },
+      },
+      {
+        '@type': 'Question',
+        name: 'Do I need an account to start playing?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'No. Core gameplay is available without registration.',
+        },
+      },
+    ],
+  };
+}
+
+export function getPublicSeoRoute(pathname: string, baseUrl: string): SeoRouteData {
+  const cleanPath = pathname.split('?')[0].split('#')[0] || '/';
+
+  if (cleanPath === '/') {
+    return {
+      title: 'Play ThaiChess Online Free | Makruk with Friends, Bot, and Puzzles',
+      description: 'Play ThaiChess online for free. Challenge friends, practice against a bot, solve Makruk puzzles, and learn the traditional Thai chess game in your browser.',
+      path: '/',
+      keywords: [...defaultKeywords, 'play with friends', 'Thai chess bot'],
+      type: 'website',
+      structuredData: [
+        buildWebsiteSchema(baseUrl),
+        buildWebApplicationSchema(baseUrl),
+        buildHomeFaqSchema(),
+      ],
+    };
+  }
+
+  if (cleanPath === '/about') {
+    return {
+      title: 'About ThaiChess | Learn Makruk and the Mission Behind the Site',
+      description: 'Learn what ThaiChess, or Makruk, is and why this open-source project exists to make traditional Thai chess easier to play and discover online.',
+      path: '/about',
+      keywords: [...defaultKeywords, 'what is Makruk', 'Thai chess rules'],
+      structuredData: [
+        {
+          '@context': 'https://schema.org',
+          '@type': 'AboutPage',
+          name: 'About ThaiChess',
+          url: `${baseUrl}/about`,
+          description: 'Background on ThaiChess, Makruk, and the project mission.',
+        },
+      ],
+    };
+  }
+
+  if (cleanPath === '/games') {
+    return {
+      title: 'Recent ThaiChess Games | Browse Finished Makruk Games',
+      description: 'Browse recent finished ThaiChess games, review results, and open move analysis for completed Makruk matches.',
+      path: '/games',
+      keywords: [...defaultKeywords, 'Thai chess games', 'Makruk game archive'],
+      structuredData: [
+        {
+          '@context': 'https://schema.org',
+          '@type': 'CollectionPage',
+          name: 'Recent ThaiChess Games',
+          url: `${baseUrl}/games`,
+          description: 'A public archive of recent completed ThaiChess games.',
+        },
+      ],
+    };
+  }
+
+  if (cleanPath === '/puzzles') {
+    return {
+      title: 'ThaiChess Puzzles | Practice Makruk Tactics Online',
+      description: 'Solve ThaiChess puzzles online and practice Makruk tactics, mating patterns, and calculation across beginner to advanced difficulty.',
+      path: '/puzzles',
+      keywords: [...defaultKeywords, 'Makruk tactics', 'Thai chess puzzles'],
+      structuredData: [
+        {
+          '@context': 'https://schema.org',
+          '@type': 'CollectionPage',
+          name: 'ThaiChess Puzzles',
+          url: `${baseUrl}/puzzles`,
+          description: 'A collection of interactive ThaiChess puzzles.',
+        },
+      ],
+    };
+  }
+
+  if (cleanPath.startsWith('/puzzle/')) {
+    const id = Number(cleanPath.split('/')[2]);
+    const puzzle = PUZZLES.find((entry) => entry.id === id);
+    const puzzleTitle = puzzle?.title ?? `Puzzle ${id}`;
+    const puzzleDescription = puzzle?.description ?? 'Interactive ThaiChess puzzle.';
+
+    return {
+      title: `${puzzleTitle} | ThaiChess Puzzle ${id}`,
+      description: `${puzzleDescription} Practice this ThaiChess puzzle online and improve your Makruk calculation.`,
+      path: cleanPath,
+      keywords: [...defaultKeywords, 'interactive puzzle', puzzleTitle],
+      structuredData: [
+        {
+          '@context': 'https://schema.org',
+          '@type': 'Quiz',
+          name: `${puzzleTitle} | ThaiChess Puzzle ${id}`,
+          educationalLevel: puzzle?.difficulty ?? 'all',
+          learningResourceType: 'Practice problem',
+          about: ['ThaiChess', 'Makruk tactics'],
+          url: `${baseUrl}${cleanPath}`,
+          description: puzzleDescription,
+        },
+      ],
+    };
+  }
+
+  if (cleanPath === '/quick-play') {
+    return {
+      title: 'Quick Play ThaiChess | Find an Online Makruk Opponent',
+      description: 'Start a quick ThaiChess game online and get matched with an opponent for a fast Makruk game in your browser.',
+      path: '/quick-play',
+      keywords: [...defaultKeywords, 'quick play', 'online matchmaking'],
+    };
+  }
+
+  if (cleanPath === '/bot') {
+    return {
+      title: 'Play ThaiChess Against Bot | Makruk Practice Online',
+      description: 'Practice ThaiChess against a bot in your browser and sharpen your Makruk openings, tactics, and endgames.',
+      path: '/bot',
+      keywords: [...defaultKeywords, 'Thai chess bot', 'practice Makruk'],
+    };
+  }
+
+  if (cleanPath === '/local') {
+    return {
+      title: 'Local ThaiChess Board | Play Makruk on One Device',
+      description: 'Use a local ThaiChess board to play Makruk on one device for study, over-the-board practice, or casual games.',
+      path: '/local',
+      keywords: [...defaultKeywords, 'local board', 'over the board'],
+    };
+  }
+
+  if (cleanPath.startsWith('/game/') || cleanPath.startsWith('/analysis/') || cleanPath === '/feedback' || cleanPath === '/login' || cleanPath === '/account') {
+    return {
+      title: 'ThaiChess',
+      description: 'Play ThaiChess online.',
+      path: cleanPath,
+      robots: 'noindex, nofollow',
+    };
+  }
+
+  return {
+    title: 'ThaiChess | Play Makruk Online',
+    description: 'Play ThaiChess online for free and explore the traditional Thai chess game.',
+    path: cleanPath,
+    keywords: defaultKeywords,
+  };
+}
+
+export function getIndexablePaths(): string[] {
+  return [
+    '/',
+    '/about',
+    '/games',
+    '/puzzles',
+    '/quick-play',
+    '/bot',
+    '/local',
+    ...PUZZLES.map((puzzle) => `/puzzle/${puzzle.id}`),
+  ];
+}


### PR DESCRIPTION
## Summary
- add route-aware SEO metadata and canonical tags for public pages
- add JSON-LD structured data for search and answer engines
- add robots.txt, sitemap.xml, and server-side head injection for SPA routes
- set production SITE_URL to https://thaichess.dev

## Verification
- npm run build