### PR TITLE
Centralize game route helpers

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import HomePage from './components/HomePage';
 import FeedbackWidget from './components/FeedbackWidget';
+import { routes } from './lib/routes';
 import { SeoHeadManager } from './lib/seo';
 
 // Lazy load route components for code splitting
@@ -40,21 +41,21 @@ export default function App() {
       </a>
       <Suspense fallback={<RouteFallback />}>
         <Routes>
-          <Route path="/" element={<HomePage />} />
-          <Route path="/game/:gameId" element={<GamePage />} />
-          <Route path="/local" element={<LocalGame />} />
-          <Route path="/bot" element={<BotGame />} />
-          <Route path="/puzzles" element={<PuzzleListPage />} />
-          <Route path="/puzzle/:id" element={<PuzzlePlayer />} />
-          <Route path="/quick-play" element={<QuickPlay />} />
-          <Route path="/about" element={<AboutPage />} />
-          <Route path="/games" element={<GamesPage />} />
-          <Route path="/leaderboard" element={<LeaderboardPage />} />
-          <Route path="/analysis/:gameId" element={<AnalysisPage />} />
-          <Route path="/analysis" element={<AnalysisPage />} />
-          <Route path="/feedback" element={<FeedbackMessagesPage />} />
-          <Route path="/login" element={<LoginPage />} />
-          <Route path="/account" element={<AccountPage />} />
+          <Route path={routes.home} element={<HomePage />} />
+          <Route path={routes.liveGamePattern} element={<GamePage />} />
+          <Route path={routes.local} element={<LocalGame />} />
+          <Route path={routes.bot} element={<BotGame />} />
+          <Route path={routes.puzzles} element={<PuzzleListPage />} />
+          <Route path={routes.puzzlePattern} element={<PuzzlePlayer />} />
+          <Route path={routes.quickPlay} element={<QuickPlay />} />
+          <Route path={routes.about} element={<AboutPage />} />
+          <Route path={routes.games} element={<GamesPage />} />
+          <Route path={routes.leaderboard} element={<LeaderboardPage />} />
+          <Route path={routes.analysisPattern} element={<AnalysisPage />} />
+          <Route path={routes.analysisRoot} element={<AnalysisPage />} />
+          <Route path={routes.feedback} element={<FeedbackMessagesPage />} />
+          <Route path={routes.login} element={<LoginPage />} />
+          <Route path={routes.account} element={<AccountPage />} />
         </Routes>
       </Suspense>
       <FeedbackWidget />

--- a/client/src/components/GamePage.tsx
+++ b/client/src/components/GamePage.tsx
@@ -6,6 +6,7 @@ import { socket, connectSocket } from '../lib/socket';
 import { playMoveSound, playCaptureSound, playCheckSound, playGameOverSound, playGameStartSound } from '../lib/sounds';
 import { useTranslation } from '../lib/i18n';
 import { usePieceStyle } from '../lib/pieceStyle';
+import { liveGameRoute, routes, savedGameAnalysisRoute } from '../lib/routes';
 import { useGameInteraction } from '../hooks/useGameInteraction';
 import { BoardErrorBoundary } from './BoardErrorBoundary';
 import Board from './Board';
@@ -154,7 +155,7 @@ export default function GamePage() {
       cancelPremove();
       setArrows([]);
       setViewMoveIndex(null);
-      navigate(`/game/${newGameId}`);
+      navigate(liveGameRoute(newGameId));
     };
 
     const handleError = ({ message }: { message: string }) => {
@@ -280,7 +281,7 @@ export default function GamePage() {
     if (gameState?.status === 'waiting') {
       socket.emit('leave_game', { gameId: gameState.gameId });
     }
-    navigate('/');
+    navigate(routes.home);
   };
 
   const copyGameLink = () => {
@@ -398,7 +399,7 @@ export default function GamePage() {
             <div className="text-4xl mb-4">⚠️</div>
             <h2 className="text-lg sm:text-xl font-bold text-danger mb-2">{t('game.error')}</h2>
             <p className="text-text-dim mb-4 text-sm sm:text-base">{error}</p>
-            <button onClick={() => navigate('/')} className="px-6 py-2 bg-primary text-white rounded-lg font-semibold text-sm sm:text-base">
+            <button onClick={() => navigate(routes.home)} className="px-6 py-2 bg-primary text-white rounded-lg font-semibold text-sm sm:text-base">
               {t('common.back_home')}
             </button>
           </div>
@@ -463,7 +464,7 @@ export default function GamePage() {
       {/* Compact Header for playing state */}
       <header className="bg-surface-alt border-b border-surface-hover">
         <div className="max-w-6xl mx-auto px-4 py-2 flex items-center justify-between gap-2 flex-wrap">
-          <button onClick={() => navigate('/')} className="flex items-center gap-2 hover:opacity-80 transition-opacity">
+          <button onClick={() => navigate(routes.home)} className="flex items-center gap-2 hover:opacity-80 transition-opacity">
             <PieceSVG type="K" color="white" size={32} />
             <h1 className="text-lg font-bold text-text-bright tracking-tight">{t('app.name')}</h1>
           </button>
@@ -631,8 +632,8 @@ export default function GamePage() {
                 ratingChange={gameOverInfo.ratingChange}
                 onRematch={handleRematch}
                 onNewGame={handleNewGame}
-                onAnalyze={gameState.moveHistory.length > 0
-                  ? () => navigate(`/analysis/${gameId}`)
+                onAnalyze={gameId && gameState.moveHistory.length > 0
+                  ? () => navigate(savedGameAnalysisRoute(gameId))
                   : undefined
                 }
               />
@@ -702,8 +703,8 @@ export default function GamePage() {
           ratingChange={gameOverInfo.ratingChange}
           onRematch={handleRematch}
           onNewGame={handleNewGame}
-          onAnalyze={gameState && gameState.moveHistory.length > 0
-            ? () => navigate(`/analysis/${gameId}`)
+          onAnalyze={gameId && gameState && gameState.moveHistory.length > 0
+            ? () => navigate(savedGameAnalysisRoute(gameId))
             : undefined
           }
           onClose={() => setShowGameOverModal(false)}

--- a/client/src/components/GamesPage.tsx
+++ b/client/src/components/GamesPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from '../lib/i18n';
+import { routes, savedGameAnalysisRoute } from '../lib/routes';
 import Header from './Header';
 
 interface GameEntry {
@@ -81,7 +82,7 @@ export default function GamesPage() {
           <div className="flex items-center gap-3">
             <h2 className="text-xl sm:text-2xl font-bold text-text-bright">{t('games.title')}</h2>
             <button
-              onClick={() => navigate('/leaderboard')}
+              onClick={() => navigate(routes.leaderboard)}
               className="px-3 py-1.5 rounded-lg border border-surface-hover bg-surface-alt text-text-bright text-xs sm:text-sm font-semibold hover:bg-surface-hover transition-colors"
             >
               {t('games.view_leaderboard')}
@@ -100,7 +101,7 @@ export default function GamesPage() {
             <p className="text-text-dim text-base sm:text-lg mb-2">{t('games.empty')}</p>
             <p className="text-text-dim text-sm mb-6">{t('games.empty_desc')}</p>
             <button
-              onClick={() => navigate('/')}
+              onClick={() => navigate(routes.home)}
               className="px-5 sm:px-6 py-2.5 sm:py-3 bg-primary hover:bg-primary-light text-white font-semibold rounded-lg transition-colors text-sm sm:text-base"
             >
               {t('games.start')}
@@ -127,7 +128,7 @@ export default function GamesPage() {
                       <tr
                         key={game.id}
                         className="border-b border-surface-hover/50 hover:bg-surface-hover/30 cursor-pointer transition-colors"
-                        onClick={() => navigate(`/analysis/${game.id}`)}
+                        onClick={() => navigate(savedGameAnalysisRoute(game.id))}
                       >
                         <td className="px-3 sm:px-4 py-3">
                           <div className="flex flex-col gap-1">
@@ -156,7 +157,7 @@ export default function GamesPage() {
                         </td>
                         <td className="px-3 sm:px-4 py-3 text-right">
                           <button
-                            onClick={(e) => { e.stopPropagation(); navigate(`/analysis/${game.id}`); }}
+                            onClick={(e) => { e.stopPropagation(); navigate(savedGameAnalysisRoute(game.id)); }}
                             className="px-2 py-1 bg-blue-600/20 hover:bg-blue-600/40 text-blue-400 text-xs rounded transition-colors"
                             title={t('analysis.analyze')}
                           >

--- a/client/src/components/HomePage.tsx
+++ b/client/src/components/HomePage.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { socket, connectSocket } from '../lib/socket';
+import { liveGameRoute, routes } from '../lib/routes';
 
 import { useTranslation } from '../lib/i18n';
 
@@ -86,7 +87,7 @@ export default function HomePage() {
     const handleCreated = ({ gameId }: { gameId: string }) => {
       setIsCreating(false);
       cleanupCreateHandlers();
-      navigate(`/game/${gameId}`);
+      navigate(liveGameRoute(gameId));
     };
 
     const handleError = ({ message }: { message: string }) => {
@@ -120,7 +121,7 @@ export default function HomePage() {
 
   const handleJoinGame = () => {
     if (!joinId.trim()) return;
-    navigate(`/game/${joinId.trim()}`);
+    navigate(liveGameRoute(joinId.trim()));
   };
 
   return (
@@ -153,7 +154,7 @@ export default function HomePage() {
             </div>
           </div>
           <button
-            onClick={() => navigate('/quick-play')}
+            onClick={() => navigate(routes.quickPlay)}
             className="w-full py-3 px-6 bg-accent hover:bg-accent/80 text-white font-bold rounded-lg text-lg transition-colors shadow-md"
           >
             {t('home.find_opponent')}
@@ -168,7 +169,7 @@ export default function HomePage() {
             <p className="text-text-dim text-sm mb-4">{t('home.play_bot_desc')}</p>
             <p className="text-text-dim text-sm mb-4">{t('home.play_bot_long_desc')}</p>
             <button
-              onClick={() => navigate('/bot')}
+              onClick={() => navigate(routes.bot)}
               className="w-full py-3 px-6 bg-primary hover:bg-primary-light text-white font-bold rounded-lg transition-colors"
             >
               {t('home.play_bot')}
@@ -184,7 +185,7 @@ export default function HomePage() {
               <p className="text-text-dim text-sm mb-4">{t('home.puzzles_desc')}</p>
               <p className="text-text-dim text-sm mb-4">{t('home.puzzles_long_desc')}</p>
               <button
-                onClick={() => navigate('/puzzles')}
+                onClick={() => navigate(routes.puzzles)}
                 className="w-full py-3 px-6 bg-accent hover:bg-accent/80 text-white font-bold rounded-lg transition-colors"
               >
                 {t('home.puzzles')}
@@ -255,7 +256,7 @@ export default function HomePage() {
             <div className="flex-1 h-px bg-surface-hover" />
           </div>
           <button
-            onClick={() => navigate('/local')}
+            onClick={() => navigate(routes.local)}
             className="w-full mt-3 py-2 px-6 bg-surface hover:bg-surface-hover text-text border border-surface-hover font-medium rounded-lg transition-colors"
           >
             {t('home.play_local')}

--- a/client/src/components/LeaderboardPage.tsx
+++ b/client/src/components/LeaderboardPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import Header from './Header';
 import { useTranslation } from '../lib/i18n';
 import { useAuth } from '../lib/auth';
+import { routes } from '../lib/routes';
 
 interface LeaderboardEntry {
   id: string;
@@ -63,7 +64,7 @@ export default function LeaderboardPage() {
           <div className="flex items-center gap-2">
             <span className="text-text-dim text-xs sm:text-sm">{t('leaderboard.count', { count: total })}</span>
             <button
-              onClick={() => navigate('/games')}
+              onClick={() => navigate(routes.games)}
               className="px-3 py-2 rounded-lg border border-surface-hover bg-surface-alt text-text-bright text-sm font-semibold hover:bg-surface-hover transition-colors"
             >
               {t('leaderboard.view_recent')}

--- a/client/src/components/QuickPlay.tsx
+++ b/client/src/components/QuickPlay.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { socket, connectSocket } from '../lib/socket';
 import { useTranslation } from '../lib/i18n';
 import { useAuth } from '../lib/auth';
+import { liveGameRoute, routes } from '../lib/routes';
 import type { PieceColor } from '@shared/types';
 import Header from './Header';
 
@@ -43,7 +44,7 @@ export default function QuickPlay() {
       setSearching(false);
       setRequestPending(false);
       setError(null);
-      navigate(`/game/${gameId}`);
+      navigate(liveGameRoute(gameId));
     };
 
     const handleMatchmakingStarted = () => {
@@ -225,7 +226,7 @@ export default function QuickPlay() {
             )}
 
             <button
-              onClick={() => navigate('/')}
+              onClick={() => navigate(routes.home)}
               className="w-full mt-3 py-2 px-6 bg-surface hover:bg-surface-hover text-text border border-surface-hover font-medium rounded-lg transition-colors"
             >
               {t('common.back_home')}

--- a/client/src/hooks/useGameSocket.ts
+++ b/client/src/hooks/useGameSocket.ts
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { ClientGameState, PieceColor, Move, RatingChangeSummary } from '@shared/types';
 import { socket, connectSocket } from '../lib/socket';
+import { liveGameRoute, routes } from '../lib/routes';
 import { playMoveSound, playCaptureSound, playCheckSound, playGameOverSound, playGameStartSound } from '../lib/sounds';
 
 interface UseGameSocketOptions {
@@ -113,7 +114,7 @@ export function useGameSocket(options: UseGameSocketOptions): UseGameSocketRetur
       setGameState(null);
       setGameOverInfo(null);
       setDrawOffered(false);
-      navigate(`/game/${newGameId}`);
+      navigate(liveGameRoute(newGameId));
     };
 
     const handleError = ({ message }: { message: string }) => {
@@ -192,7 +193,7 @@ export function useGameActions() {
   }, []);
 
   const handleNewGame = useCallback(() => {
-    navigate('/');
+    navigate(routes.home);
   }, [navigate]);
 
   return {

--- a/client/src/lib/routes.ts
+++ b/client/src/lib/routes.ts
@@ -1,0 +1,29 @@
+export const routes = {
+  home: '/',
+  local: '/local',
+  bot: '/bot',
+  puzzles: '/puzzles',
+  quickPlay: '/quick-play',
+  about: '/about',
+  games: '/games',
+  leaderboard: '/leaderboard',
+  feedback: '/feedback',
+  login: '/login',
+  account: '/account',
+  analysisRoot: '/analysis',
+  liveGamePattern: '/game/:gameId',
+  puzzlePattern: '/puzzle/:id',
+  analysisPattern: '/analysis/:gameId',
+} as const;
+
+export function liveGameRoute(gameId: string): string {
+  return `/game/${gameId}`;
+}
+
+export function savedGameAnalysisRoute(gameId: string): string {
+  return `/analysis/${gameId}`;
+}
+
+export function puzzleRoute(id: string): string {
+  return `/puzzle/${id}`;
+}

--- a/client/src/test/routes.test.ts
+++ b/client/src/test/routes.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { liveGameRoute, routes, savedGameAnalysisRoute } from '../lib/routes';
+
+describe('routes', () => {
+  it('builds distinct routes for live games and saved-game analysis', () => {
+    expect(liveGameRoute('abc123')).toBe('/game/abc123');
+    expect(savedGameAnalysisRoute('abc123')).toBe('/analysis/abc123');
+  });
+
+  it('keeps the route patterns centralized for the router', () => {
+    expect(routes.liveGamePattern).toBe('/game/:gameId');
+    expect(routes.analysisPattern).toBe('/analysis/:gameId');
+  });
+});


### PR DESCRIPTION
## Summary
- add shared route helpers for live games, saved-game analysis, and core app routes
- replace scattered inline route strings in the main game flows with those helpers
- add regression coverage for the route helpers

## Testing
- npm run test:run --workspace=client -- GamesPage routes
- npm run test:run --workspace=client -- HomePage QuickPlay GamePage useGameSocket