### PR TITLE
fix: make reconnect identity stable and rated saves atomic

### DIFF
--- a/client/src/lib/socket.ts
+++ b/client/src/lib/socket.ts
@@ -2,6 +2,36 @@ import { io, Socket } from 'socket.io-client';
 import type { ServerToClientEvents, ClientToServerEvents } from '@shared/types';
 
 const URL = import.meta.env.DEV ? 'http://localhost:3000' : '';
+const GUEST_PLAYER_ID_STORAGE_KEY = 'thaichess_guest_player_id';
+
+function createGuestPlayerId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return `guest_${crypto.randomUUID()}`;
+  }
+
+  return `guest_${Math.random().toString(36).slice(2)}${Date.now().toString(36)}`;
+}
+
+function getGuestPlayerId() {
+  if (typeof window === 'undefined') {
+    return createGuestPlayerId();
+  }
+
+  const existing = window.localStorage.getItem(GUEST_PLAYER_ID_STORAGE_KEY);
+  if (existing) {
+    return existing;
+  }
+
+  const created = createGuestPlayerId();
+  window.localStorage.setItem(GUEST_PLAYER_ID_STORAGE_KEY, created);
+  return created;
+}
+
+function getSocketAuth() {
+  return {
+    guestPlayerId: getGuestPlayerId(),
+  };
+}
 
 export const socket: Socket<ServerToClientEvents, ClientToServerEvents> = io(URL, {
   autoConnect: false,
@@ -11,9 +41,11 @@ export const socket: Socket<ServerToClientEvents, ClientToServerEvents> = io(URL
   reconnectionDelay: 1000,
   reconnectionDelayMax: 5000,
   timeout: 10000,
+  auth: getSocketAuth(),
 });
 
 export function connectSocket() {
+  socket.auth = getSocketAuth();
   if (!socket.connected) {
     socket.connect();
   }

--- a/server/src/auth.ts
+++ b/server/src/auth.ts
@@ -18,6 +18,7 @@ const SESSION_COOKIE_NAME = 'thaichess_session';
 const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;
 const LOGIN_CODE_TTL_SECONDS = 60 * 10;
 const LOGIN_CODE_MAX_ATTEMPTS = 5;
+const GUEST_PLAYER_ID_PATTERN = /^guest_[A-Za-z0-9-]{16,128}$/;
 const ADMIN_EMAILS = new Set(
   (process.env.ADMIN_EMAILS || '')
     .split(',')
@@ -44,6 +45,13 @@ export function normalizeEmail(email: string) {
 
 export function normalizeUsername(username: string) {
   return username.trim().replace(/\s+/g, ' ');
+}
+
+export function normalizeGuestPlayerId(value: unknown) {
+  if (typeof value !== 'string') return null;
+
+  const normalized = value.trim();
+  return GUEST_PLAYER_ID_PATTERN.test(normalized) ? normalized : null;
 }
 
 export function isValidEmail(email: string) {

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -14,6 +14,7 @@ const TURSO_DATABASE_URL = process.env.TURSO_DATABASE_URL?.trim() || undefined;
 const TURSO_AUTH_TOKEN = process.env.TURSO_AUTH_TOKEN?.trim() || undefined;
 
 let db: Client;
+type SqlExecutor = Pick<Client, 'execute'>;
 
 async function ensureColumn(table: string, column: string, definition: string) {
   const result = await db.execute(`PRAGMA table_info(${table})`);
@@ -269,6 +270,15 @@ function rowToLeaderboardEntry(row: Row): LeaderboardEntry {
   };
 }
 
+async function getUserByIdFromExecutor(executor: SqlExecutor, id: string): Promise<AuthUser | null> {
+  const result = await executor.execute({
+    sql: 'SELECT * FROM users WHERE id = ? LIMIT 1',
+    args: [id],
+  });
+  const row = result.rows[0];
+  return row ? rowToAuthUser(row) : null;
+}
+
 export async function initDatabase(): Promise<void> {
   const config = getDatabaseConfig();
   db = config.client;
@@ -298,15 +308,18 @@ export async function saveCompletedGame(data: {
   whiteRatingAfter?: number | null;
   blackRatingAfter?: number | null;
 }): Promise<{ ratingChange: RatingChangeSummary | null }> {
-  try {
-    const shouldRate = Boolean(data.rated && data.whiteUserId && data.blackUserId);
-    let whiteRatingBefore = data.whiteRatingBefore ?? null;
-    let blackRatingBefore = data.blackRatingBefore ?? null;
-    let whiteRatingAfter = data.whiteRatingAfter ?? null;
-    let blackRatingAfter = data.blackRatingAfter ?? null;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    let transaction: Awaited<ReturnType<Client['transaction']>> | null = null;
 
-    if (shouldRate) {
-      const existingResult = await db.execute({
+    try {
+      transaction = await db.transaction('write');
+      const shouldRate = Boolean(data.rated && data.whiteUserId && data.blackUserId);
+      let whiteRatingBefore = data.whiteRatingBefore ?? null;
+      let blackRatingBefore = data.blackRatingBefore ?? null;
+      let whiteRatingAfter = data.whiteRatingAfter ?? null;
+      let blackRatingAfter = data.blackRatingAfter ?? null;
+
+      const existingResult = await transaction.execute({
         sql: `
           SELECT white_rating_before, black_rating_before, white_rating_after, black_rating_after
           FROM games
@@ -316,109 +329,156 @@ export async function saveCompletedGame(data: {
         args: [data.id],
       });
       const existingRow = existingResult.rows[0];
-      if (existingRow && existingRow.white_rating_after !== null && existingRow.black_rating_after !== null) {
-        return {
+      if (existingRow) {
+        await transaction.commit();
+        if (existingRow.white_rating_after !== null && existingRow.black_rating_after !== null) {
+          return {
+            ratingChange: {
+              whiteBefore: Number(existingRow.white_rating_before ?? existingRow.white_rating_after),
+              blackBefore: Number(existingRow.black_rating_before ?? existingRow.black_rating_after),
+              whiteAfter: Number(existingRow.white_rating_after),
+              blackAfter: Number(existingRow.black_rating_after),
+            },
+          };
+        }
+
+        return { ratingChange: null };
+      }
+
+      if (shouldRate) {
+        const [whiteUser, blackUser] = await Promise.all([
+          getUserByIdFromExecutor(transaction, data.whiteUserId!),
+          getUserByIdFromExecutor(transaction, data.blackUserId!),
+        ]);
+
+        if (whiteUser && blackUser) {
+          whiteRatingBefore = whiteUser.rating;
+          blackRatingBefore = blackUser.rating;
+
+          const ratingUpdate = calculateEloUpdate(whiteUser.rating, blackUser.rating, data.result);
+          whiteRatingAfter = ratingUpdate.whiteAfter;
+          blackRatingAfter = ratingUpdate.blackAfter;
+
+          await transaction.execute({
+            sql: `
+              UPDATE users
+              SET rating = ?, rated_games = rated_games + 1, wins = wins + ?, losses = losses + ?, draws = draws + ?, updated_at = unixepoch()
+              WHERE id = ?
+            `,
+            args: [
+              whiteRatingAfter,
+              data.result === 'white' ? 1 : 0,
+              data.result === 'black' ? 1 : 0,
+              data.result === 'draw' ? 1 : 0,
+              data.whiteUserId!,
+            ],
+          });
+
+          await transaction.execute({
+            sql: `
+              UPDATE users
+              SET rating = ?, rated_games = rated_games + 1, wins = wins + ?, losses = losses + ?, draws = draws + ?, updated_at = unixepoch()
+              WHERE id = ?
+            `,
+            args: [
+              blackRatingAfter,
+              data.result === 'black' ? 1 : 0,
+              data.result === 'white' ? 1 : 0,
+              data.result === 'draw' ? 1 : 0,
+              data.blackUserId!,
+            ],
+          });
+        }
+      }
+
+      const appliedRatedGame = shouldRate
+        && whiteRatingBefore !== null
+        && blackRatingBefore !== null
+        && whiteRatingAfter !== null
+        && blackRatingAfter !== null;
+
+      await transaction.execute({
+        sql: `
+          INSERT OR REPLACE INTO games (
+            id, white_user_id, black_user_id, result, result_reason, rated, game_mode, white_rating_before, black_rating_before,
+            white_rating_after, black_rating_after, time_control_initial, time_control_increment, moves, final_board, move_count, finished_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, unixepoch())
+        `,
+        args: [
+          data.id,
+          data.whiteUserId ?? null,
+          data.blackUserId ?? null,
+          data.result,
+          data.resultReason,
+          appliedRatedGame ? 1 : 0,
+          data.gameMode ?? 'private',
+          whiteRatingBefore,
+          blackRatingBefore,
+          whiteRatingAfter,
+          blackRatingAfter,
+          data.timeControl.initial,
+          data.timeControl.increment,
+          JSON.stringify(data.moves),
+          JSON.stringify(data.finalBoard),
+          data.moveCount,
+        ],
+      });
+
+      await transaction.commit();
+
+      return appliedRatedGame
+        ? {
           ratingChange: {
-            whiteBefore: Number(existingRow.white_rating_before ?? existingRow.white_rating_after),
-            blackBefore: Number(existingRow.black_rating_before ?? existingRow.black_rating_after),
-            whiteAfter: Number(existingRow.white_rating_after),
-            blackAfter: Number(existingRow.black_rating_after),
+            whiteBefore: whiteRatingBefore!,
+            blackBefore: blackRatingBefore!,
+            whiteAfter: whiteRatingAfter!,
+            blackAfter: blackRatingAfter!,
           },
-        };
+        }
+        : { ratingChange: null };
+    } catch (err) {
+      if (transaction && !transaction.closed) {
+        await transaction.rollback().catch(() => undefined);
       }
-
-      const [whiteUser, blackUser] = await Promise.all([
-        getUserById(data.whiteUserId!),
-        getUserById(data.blackUserId!),
-      ]);
-
-      if (whiteUser && blackUser) {
-        whiteRatingBefore = whiteUser.rating;
-        blackRatingBefore = blackUser.rating;
-
-        const ratingUpdate = calculateEloUpdate(whiteUser.rating, blackUser.rating, data.result);
-        whiteRatingAfter = ratingUpdate.whiteAfter;
-        blackRatingAfter = ratingUpdate.blackAfter;
-
-        await db.execute({
-          sql: `
-            UPDATE users
-            SET rating = ?, rated_games = rated_games + 1, wins = wins + ?, losses = losses + ?, draws = draws + ?, updated_at = unixepoch()
-            WHERE id = ?
-          `,
-          args: [
-            whiteRatingAfter,
-            data.result === 'white' ? 1 : 0,
-            data.result === 'black' ? 1 : 0,
-            data.result === 'draw' ? 1 : 0,
-            data.whiteUserId!,
-          ],
-        });
-
-        await db.execute({
-          sql: `
-            UPDATE users
-            SET rating = ?, rated_games = rated_games + 1, wins = wins + ?, losses = losses + ?, draws = draws + ?, updated_at = unixepoch()
-            WHERE id = ?
-          `,
-          args: [
-            blackRatingAfter,
-            data.result === 'black' ? 1 : 0,
-            data.result === 'white' ? 1 : 0,
-            data.result === 'draw' ? 1 : 0,
-            data.blackUserId!,
-          ],
-        });
+      if (isSqliteBusyError(err) && attempt < 2) {
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        continue;
       }
+      if (isSqliteBusyError(err)) {
+        const existingResult = await db.execute({
+          sql: `
+            SELECT white_rating_before, black_rating_before, white_rating_after, black_rating_after
+            FROM games
+            WHERE id = ?
+            LIMIT 1
+          `,
+          args: [data.id],
+        });
+        const existingRow = existingResult.rows[0];
+        if (existingRow) {
+          if (existingRow.white_rating_after !== null && existingRow.black_rating_after !== null) {
+            return {
+              ratingChange: {
+                whiteBefore: Number(existingRow.white_rating_before ?? existingRow.white_rating_after),
+                blackBefore: Number(existingRow.black_rating_before ?? existingRow.black_rating_after),
+                whiteAfter: Number(existingRow.white_rating_after),
+                blackAfter: Number(existingRow.black_rating_after),
+              },
+            };
+          }
+
+          return { ratingChange: null };
+        }
+      }
+      logError('database_save_completed_game_failed', err, { gameId: data.id, attempt: attempt + 1 });
+      return { ratingChange: null };
+    } finally {
+      transaction?.close();
     }
-
-    const appliedRatedGame = shouldRate
-      && whiteRatingBefore !== null
-      && blackRatingBefore !== null
-      && whiteRatingAfter !== null
-      && blackRatingAfter !== null;
-
-    await db.execute({
-      sql: `
-        INSERT OR REPLACE INTO games (
-          id, white_user_id, black_user_id, result, result_reason, rated, game_mode, white_rating_before, black_rating_before,
-          white_rating_after, black_rating_after, time_control_initial, time_control_increment, moves, final_board, move_count, finished_at
-        )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, unixepoch())
-      `,
-      args: [
-        data.id,
-        data.whiteUserId ?? null,
-        data.blackUserId ?? null,
-        data.result,
-        data.resultReason,
-        appliedRatedGame ? 1 : 0,
-        data.gameMode ?? 'private',
-        whiteRatingBefore,
-        blackRatingBefore,
-        whiteRatingAfter,
-        blackRatingAfter,
-        data.timeControl.initial,
-        data.timeControl.increment,
-        JSON.stringify(data.moves),
-        JSON.stringify(data.finalBoard),
-        data.moveCount,
-      ],
-    });
-    return appliedRatedGame
-      ? {
-        ratingChange: {
-          whiteBefore: whiteRatingBefore!,
-          blackBefore: blackRatingBefore!,
-          whiteAfter: whiteRatingAfter!,
-          blackAfter: blackRatingAfter!,
-        },
-      }
-      : { ratingChange: null };
-  } catch (err) {
-    logError('database_save_completed_game_failed', err, { gameId: data.id });
-    return { ratingChange: null };
   }
+
+  return { ratingChange: null };
 }
 
 function calculateEloUpdate(
@@ -436,6 +496,10 @@ function calculateEloUpdate(
     whiteAfter: whiteRating + whiteDelta,
     blackAfter: blackRating + blackDelta,
   };
+}
+
+function isSqliteBusyError(error: unknown) {
+  return error instanceof Error && error.message.includes('SQLITE_BUSY');
 }
 
 export interface SavedGame {

--- a/server/src/gameManager.ts
+++ b/server/src/gameManager.ts
@@ -1,14 +1,15 @@
 import { v4 as uuidv4 } from 'uuid';
 import {
-  GameRoom, GameState, TimeControl, PieceColor, PrivateGameColorPreference, GameMode,
+  GameRoom, TimeControl, PieceColor, PrivateGameColorPreference, GameMode,
   Position, ClientGameState, Move,
 } from '../../shared/types';
 import { createInitialGameState, makeMove, startCounting, stopCounting } from '../../shared/engine';
 
 export class GameManager {
   private games: Map<string, GameRoom> = new Map();
-  private playerGames: Map<string, string> = new Map(); // socketId -> gameId
-  private clockIntervals: Map<string, NodeJS.Timeout> = new Map();
+  private playerGames: Map<string, string> = new Map(); // playerId -> gameId
+  private socketGames: Map<string, string> = new Map(); // socketId -> gameId
+  private clockIntervals: Map<string, ReturnType<typeof setInterval>> = new Map();
   private disconnectedPlayers: Map<string, number> = new Map();
   private roomLastActivity: Map<string, number> = new Map();
   private static readonly CLOCK_TICK_MS = 500;
@@ -20,6 +21,7 @@ export class GameManager {
     timeControl: TimeControl,
     options: {
       ownerSocketId?: string;
+      ownerPlayerId?: string;
       ownerUserId?: string | null;
       ownerColorPreference?: PrivateGameColorPreference;
       gameMode?: GameMode;
@@ -30,6 +32,7 @@ export class GameManager {
     const initialMs = timeControl.initial * 1000;
     const gameState = createInitialGameState(initialMs, initialMs);
     const ownerColorPreference = options.ownerColorPreference ?? 'random';
+    const ownerPlayerId = options.ownerPlayerId ?? options.ownerSocketId ?? null;
     const resolvedOwnerColor = ownerColorPreference === 'random'
       ? (Math.random() < 0.5 ? 'white' : 'black')
       : ownerColorPreference;
@@ -38,6 +41,8 @@ export class GameManager {
       id,
       white: options.ownerSocketId && resolvedOwnerColor === 'white' ? options.ownerSocketId : null,
       black: options.ownerSocketId && resolvedOwnerColor === 'black' ? options.ownerSocketId : null,
+      whitePlayerId: ownerPlayerId && resolvedOwnerColor === 'white' ? ownerPlayerId : null,
+      blackPlayerId: ownerPlayerId && resolvedOwnerColor === 'black' ? ownerPlayerId : null,
       whiteUserId: options.ownerSocketId && resolvedOwnerColor === 'white' ? (options.ownerUserId ?? null) : null,
       blackUserId: options.ownerSocketId && resolvedOwnerColor === 'black' ? (options.ownerUserId ?? null) : null,
       spectators: [],
@@ -53,53 +58,89 @@ export class GameManager {
 
     this.games.set(id, room);
     if (options.ownerSocketId) {
-      this.playerGames.set(options.ownerSocketId, id);
+      this.socketGames.set(options.ownerSocketId, id);
+    }
+    if (ownerPlayerId) {
+      this.playerGames.set(ownerPlayerId, id);
     }
     this.touchGame(id);
     return room;
   }
 
-  joinGame(gameId: string, socketId: string, options: { userId?: string | null } = {}): { room: GameRoom; color: PieceColor } | null {
+  joinGame(gameId: string, socketId: string, options: { playerId?: string; userId?: string | null } = {}): { room: GameRoom; color: PieceColor; reconnected: boolean } | null {
     const room = this.games.get(gameId);
     if (!room) return null;
+    const playerId = options.playerId ?? socketId;
 
-    // Reconnection: if this player was already in the game
+    // Same live connection joining again.
     if (room.white === socketId || room.black === socketId) {
       const color = room.white === socketId ? 'white' : 'black';
-      return { room, color };
+      this.socketGames.set(socketId, gameId);
+      return { room, color, reconnected: false };
+    }
+
+    // Reconnection: restore the player's seat using the durable player id.
+    if (room.whitePlayerId === playerId) {
+      if (room.white && room.white !== socketId) {
+        this.socketGames.delete(room.white);
+      }
+      room.white = socketId;
+      room.whiteUserId = options.userId ?? room.whiteUserId;
+      this.socketGames.set(socketId, gameId);
+      this.playerGames.set(playerId, gameId);
+      this.clearDisconnectedPlayer(gameId, 'white');
+      this.touchGame(gameId);
+      return { room, color: 'white', reconnected: true };
+    }
+
+    if (room.blackPlayerId === playerId) {
+      if (room.black && room.black !== socketId) {
+        this.socketGames.delete(room.black);
+      }
+      room.black = socketId;
+      room.blackUserId = options.userId ?? room.blackUserId;
+      this.socketGames.set(socketId, gameId);
+      this.playerGames.set(playerId, gameId);
+      this.clearDisconnectedPlayer(gameId, 'black');
+      this.touchGame(gameId);
+      return { room, color: 'black', reconnected: true };
     }
 
     if (!room.white) {
       room.white = socketId;
+      room.whitePlayerId = playerId;
       room.whiteUserId = options.userId ?? null;
-      this.playerGames.set(socketId, gameId);
+      this.socketGames.set(socketId, gameId);
+      this.playerGames.set(playerId, gameId);
       this.clearDisconnectedPlayer(gameId, 'white');
       if (room.status === 'waiting' && room.black) {
         room.status = 'playing';
         room.gameState.lastMoveTime = Date.now();
       }
       this.touchGame(gameId);
-      return { room, color: 'white' };
+      return { room, color: 'white', reconnected: false };
     }
 
     if (!room.black) {
       room.black = socketId;
+      room.blackPlayerId = playerId;
       room.blackUserId = options.userId ?? null;
-      this.playerGames.set(socketId, gameId);
+      this.socketGames.set(socketId, gameId);
+      this.playerGames.set(playerId, gameId);
       this.clearDisconnectedPlayer(gameId, 'black');
       if (room.status === 'waiting') {
         room.status = 'playing';
         room.gameState.lastMoveTime = Date.now();
       }
       this.touchGame(gameId);
-      return { room, color: 'black' };
+      return { room, color: 'black', reconnected: false };
     }
 
     // Game is full, join as spectator
     if (!room.spectators.includes(socketId)) {
       room.spectators.push(socketId);
     }
-    this.playerGames.set(socketId, gameId);
+    this.socketGames.set(socketId, gameId);
     this.touchGame(gameId);
     return null;
   }
@@ -251,13 +292,17 @@ export class GameManager {
     // Swap colors for rematch
     newRoom.white = oldRoom.black;
     newRoom.black = oldRoom.white;
+    newRoom.whitePlayerId = oldRoom.blackPlayerId;
+    newRoom.blackPlayerId = oldRoom.whitePlayerId;
     newRoom.whiteUserId = oldRoom.blackUserId;
     newRoom.blackUserId = oldRoom.whiteUserId;
     newRoom.gameMode = oldRoom.gameMode;
     newRoom.rated = oldRoom.rated;
 
-    if (newRoom.white) this.playerGames.set(newRoom.white, newRoom.id);
-    if (newRoom.black) this.playerGames.set(newRoom.black, newRoom.id);
+    if (newRoom.white) this.socketGames.set(newRoom.white, newRoom.id);
+    if (newRoom.black) this.socketGames.set(newRoom.black, newRoom.id);
+    if (newRoom.whitePlayerId) this.playerGames.set(newRoom.whitePlayerId, newRoom.id);
+    if (newRoom.blackPlayerId) this.playerGames.set(newRoom.blackPlayerId, newRoom.id);
 
     if (newRoom.white && newRoom.black) {
       newRoom.status = 'playing';
@@ -269,14 +314,14 @@ export class GameManager {
   }
 
   handleDisconnect(socketId: string): { gameId: string; color: PieceColor } | null {
-    const gameId = this.playerGames.get(socketId);
+    const gameId = this.socketGames.get(socketId);
     if (!gameId) return null;
 
     const room = this.games.get(gameId);
     if (!room) return null;
 
     const color = this.getPlayerColor(room, socketId);
-    this.playerGames.delete(socketId);
+    this.socketGames.delete(socketId);
     room.spectators = room.spectators.filter((spectatorId) => spectatorId !== socketId);
 
     if (color) {
@@ -288,21 +333,27 @@ export class GameManager {
     return color ? { gameId, color } : null;
   }
 
-  updatePlayerSocket(gameId: string, oldSocketId: string, newSocketId: string): void {
+  updatePlayerSocket(gameId: string, playerId: string, newSocketId: string): void {
     const room = this.games.get(gameId);
     if (!room) return;
 
-    if (room.white === oldSocketId) {
+    if (room.whitePlayerId === playerId) {
+      if (room.white) {
+        this.socketGames.delete(room.white);
+      }
       room.white = newSocketId;
       this.clearDisconnectedPlayer(gameId, 'white');
     }
-    if (room.black === oldSocketId) {
+    if (room.blackPlayerId === playerId) {
+      if (room.black) {
+        this.socketGames.delete(room.black);
+      }
       room.black = newSocketId;
       this.clearDisconnectedPlayer(gameId, 'black');
     }
 
-    this.playerGames.delete(oldSocketId);
-    this.playerGames.set(newSocketId, gameId);
+    this.socketGames.set(newSocketId, gameId);
+    this.playerGames.set(playerId, gameId);
     this.touchGame(gameId);
   }
 
@@ -329,40 +380,45 @@ export class GameManager {
     };
   }
 
-  getPlayerGame(socketId: string): string | null {
-    return this.playerGames.get(socketId) || null;
+  getPlayerGame(playerId: string): string | null {
+    return this.playerGames.get(playerId) || null;
   }
 
-  getBlockingPlayerGame(socketId: string): string | null {
-    const gameId = this.playerGames.get(socketId);
+  getBlockingPlayerGame(playerId: string): string | null {
+    const gameId = this.playerGames.get(playerId);
     if (!gameId) return null;
 
     const room = this.games.get(gameId);
     if (!room) {
-      this.playerGames.delete(socketId);
+      this.playerGames.delete(playerId);
       return null;
     }
 
     if (room.status === 'finished') {
-      this.playerGames.delete(socketId);
+      this.playerGames.delete(playerId);
       return null;
     }
 
     return gameId;
   }
 
-  setPlayerGame(socketId: string, gameId: string): void {
-    this.playerGames.set(socketId, gameId);
+  setPlayerGame(playerId: string, gameId: string): void {
+    this.playerGames.set(playerId, gameId);
+    this.touchGame(gameId);
+  }
+
+  setSocketGame(socketId: string, gameId: string): void {
+    this.socketGames.set(socketId, gameId);
     this.touchGame(gameId);
   }
 
   leaveGame(socketId: string, requestedGameId?: string): { gameId: string; deleted: boolean } | null {
-    const gameId = this.playerGames.get(socketId);
+    const gameId = this.socketGames.get(socketId);
     if (!gameId || (requestedGameId && requestedGameId !== gameId)) return null;
 
     const room = this.games.get(gameId);
     if (!room) {
-      this.playerGames.delete(socketId);
+      this.socketGames.delete(socketId);
       return null;
     }
 
@@ -372,15 +428,23 @@ export class GameManager {
     }
 
     if (room.white === socketId) {
+      if (room.whitePlayerId) {
+        this.playerGames.delete(room.whitePlayerId);
+      }
       room.white = null;
+      room.whitePlayerId = null;
       room.whiteUserId = null;
     }
     if (room.black === socketId) {
+      if (room.blackPlayerId) {
+        this.playerGames.delete(room.blackPlayerId);
+      }
       room.black = null;
+      room.blackPlayerId = null;
       room.blackUserId = null;
     }
     room.spectators = room.spectators.filter((spectatorId) => spectatorId !== socketId);
-    this.playerGames.delete(socketId);
+    this.socketGames.delete(socketId);
     this.touchGame(gameId);
 
     const shouldDelete = room.status === 'waiting' && !room.white && !room.black && room.spectators.length === 0;
@@ -437,7 +501,8 @@ export class GameManager {
     room.gameState.lastMoveTime = now;
   }
 
-  startClock(gameId: string, onTick: (room: GameRoom) => void): void {
+  // eslint-disable-next-line no-unused-vars
+  startClock(gameId: string, onTick: (...args: [GameRoom]) => void): void {
     this.stopClock(gameId);
 
     const interval = setInterval(() => {
@@ -518,11 +583,13 @@ export class GameManager {
     this.clearDisconnectedPlayer(gameId, 'white');
     this.clearDisconnectedPlayer(gameId, 'black');
 
-    if (room.white) this.playerGames.delete(room.white);
-    if (room.black) this.playerGames.delete(room.black);
+    if (room.white) this.socketGames.delete(room.white);
+    if (room.black) this.socketGames.delete(room.black);
+    if (room.whitePlayerId) this.playerGames.delete(room.whitePlayerId);
+    if (room.blackPlayerId) this.playerGames.delete(room.blackPlayerId);
 
     for (const spectatorId of room.spectators) {
-      this.playerGames.delete(spectatorId);
+      this.socketGames.delete(spectatorId);
     }
   }
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,19 +1,19 @@
 import express from 'express';
 import { createServer } from 'http';
-import { Server, type Socket } from 'socket.io';
+import { Server } from 'socket.io';
 import cors from 'cors';
 import fs from 'fs';
 import path from 'path';
 import rateLimit from 'express-rate-limit';
 import { GameManager } from './gameManager';
-import { MatchmakingQueue, QueueEntry } from './matchmaking';
+import { MatchmakingQueue } from './matchmaking';
 import { initDatabase, saveCompletedGame, getRecentGames, getGame as getDbGame, getStats, getGameCount, getLeaderboard, getLeaderboardCount, saveFeedback, getFeedbackCount, getFeedbackForAdmin, moderateFeedback, updateUsername } from './database';
 import { ServerToClientEvents, ClientToServerEvents, GameRoom } from '../../shared/types';
 import { getIndexablePaths, getPublicSeoRoute } from '../../shared/seo';
 import { logError, logInfo, logWarn } from './logger';
 import { MonitoringStore } from './monitoring';
-import { getSocketIp, isValidBoolean, isValidGameId, isValidPosition, isValidTimeControl, SocketRateLimiter } from './security';
-import { clearSessionCookie, getAuthenticatedUser, getAuthenticatedUserFromCookieHeader, isValidEmail, isValidUsername, issueLoginCode, logoutRequest, normalizeEmail, normalizeUsername, setSessionCookie, verifyLoginCode } from './auth';
+import { SocketRateLimiter } from './security';
+import { clearSessionCookie, getAuthenticatedUser, getAuthenticatedUserFromCookieHeader, isValidEmail, isValidUsername, issueLoginCode, logoutRequest, normalizeEmail, normalizeGuestPlayerId, normalizeUsername, setSessionCookie, verifyLoginCode } from './auth';
 import { createSocketConnectionHandler, type AuthenticatedSocketData } from './socketHandlers';
 import { shouldServeSpaShell } from './spa';
 import { normalizeLeaderboardLimit, normalizeLeaderboardPage } from './leaderboardPagination';
@@ -176,7 +176,10 @@ async function saveGameToDb(room: GameRoom, reason: string) {
 
 io.use(async (socket, next) => {
   try {
-    socket.data.authUser = await getAuthenticatedUserFromCookieHeader(socket.handshake.headers.cookie);
+    const authUser = await getAuthenticatedUserFromCookieHeader(socket.handshake.headers.cookie);
+    const guestPlayerId = normalizeGuestPlayerId(socket.handshake.auth?.guestPlayerId);
+    socket.data.authUser = authUser;
+    socket.data.playerId = authUser?.id ?? guestPlayerId ?? `guest_${socket.id}`;
     next();
   } catch (error) {
     next(error instanceof Error ? error : new Error('Socket authentication failed.'));

--- a/server/src/matchmaking.ts
+++ b/server/src/matchmaking.ts
@@ -2,6 +2,7 @@ import { TimeControl } from '../../shared/types';
 
 export interface QueueEntry {
   socketId: string;
+  playerId: string;
   userId: string | null;
   timeControl: TimeControl;
   joinedAt: number;
@@ -11,11 +12,12 @@ export class MatchmakingQueue {
   private queue: QueueEntry[] = [];
   private playerInQueue: Map<string, number> = new Map();
 
-  addToQueue(socketId: string, timeControl: TimeControl, options: { userId?: string | null } = {}): void {
+  addToQueue(socketId: string, timeControl: TimeControl, options: { playerId: string; userId?: string | null }): void {
     this.removeFromQueue(socketId);
 
     this.queue.push({
       socketId,
+      playerId: options.playerId,
       userId: options.userId ?? null,
       timeControl,
       joinedAt: Date.now(),

--- a/server/src/socketHandlers.ts
+++ b/server/src/socketHandlers.ts
@@ -1,4 +1,4 @@
-import type { Socket } from 'socket.io';
+import type { Server, Socket } from 'socket.io';
 import { logInfo, logWarn } from './logger';
 import type { ServerToClientEvents, ClientToServerEvents, GameRoom, RatingChangeSummary } from '../../shared/types';
 import type { GameManager } from './gameManager';
@@ -17,17 +17,11 @@ import {
 
 export interface AuthenticatedSocketData {
   authUser: AuthUser | null;
+  playerId: string;
 }
 
 type ServerSocket = Socket<ClientToServerEvents, ServerToClientEvents, Record<string, never>, AuthenticatedSocketData>;
-
-type SocketTarget = {
-  emit: (...args: any[]) => unknown;
-};
-
-type IoLike = {
-  to: (roomOrSocketId: string) => SocketTarget;
-};
+type IoLike = Pick<Server<ClientToServerEvents, ServerToClientEvents, Record<string, never>, AuthenticatedSocketData>, 'to'>;
 
 export const SOCKET_RATE_LIMITS = {
   create_game: { windowMs: 60 * 1000, max: 6 },
@@ -45,7 +39,8 @@ interface SocketHandlerDeps {
   socketRateLimiter: SocketRateLimiter;
   ipRateLimiter: SocketRateLimiter;
   monitoring: MonitoringStore;
-  saveGameToDb: (room: GameRoom, reason: string) => Promise<{ ratingChange: RatingChangeSummary | null }>;
+  // eslint-disable-next-line no-unused-vars
+  saveGameToDb: (...args: [GameRoom, string]) => Promise<{ ratingChange: RatingChangeSummary | null }>;
 }
 
 function emitQueueStatusForEntry(io: IoLike, matchmaking: MatchmakingQueue, entry: QueueEntry) {
@@ -148,13 +143,17 @@ function tryMatchmakeQueue(deps: SocketHandlerDeps) {
 
       room.white = whiteId;
       room.black = blackId;
+      room.whitePlayerId = whiteEntry.playerId;
+      room.blackPlayerId = blackEntry.playerId;
       room.whiteUserId = whiteEntry.userId;
       room.blackUserId = blackEntry.userId;
       room.status = 'playing';
       room.gameState.lastMoveTime = Date.now();
 
-      deps.gameManager.setPlayerGame(whiteId, room.id);
-      deps.gameManager.setPlayerGame(blackId, room.id);
+      deps.gameManager.setSocketGame(whiteId, room.id);
+      deps.gameManager.setSocketGame(blackId, room.id);
+      deps.gameManager.setPlayerGame(whiteEntry.playerId, room.id);
+      deps.gameManager.setPlayerGame(blackEntry.playerId, room.id);
       deps.monitoring.increment('matchmakingMatched');
 
       logInfo('match_found', { whiteId, blackId, gameId: room.id });
@@ -182,13 +181,14 @@ export function createSocketConnectionHandler(deps: SocketHandlerDeps) {
         rejectSocketEvent(deps.monitoring, socket, 'create_game', 'Invalid private game settings.');
         return;
       }
-      if (deps.gameManager.getBlockingPlayerGame(socket.id) || deps.matchmaking.isInQueue(socket.id)) {
+      if (deps.gameManager.getBlockingPlayerGame(socket.data.playerId) || deps.matchmaking.isInQueue(socket.id)) {
         rejectSocketEvent(deps.monitoring, socket, 'create_game', 'Leave your current game or queue before creating another game.');
         return;
       }
 
       const room = deps.gameManager.createGame(payload.timeControl, {
         ownerSocketId: socket.id,
+        ownerPlayerId: socket.data.playerId,
         ownerUserId: socket.data.authUser?.id ?? null,
         ownerColorPreference: payload.colorPreference,
         gameMode: 'private',
@@ -227,13 +227,14 @@ export function createSocketConnectionHandler(deps: SocketHandlerDeps) {
       }
 
       const { gameId } = payload;
-      const currentGameId = deps.gameManager.getBlockingPlayerGame(socket.id);
+      const currentGameId = deps.gameManager.getBlockingPlayerGame(socket.data.playerId);
       if (currentGameId && currentGameId !== gameId) {
         rejectSocketEvent(deps.monitoring, socket, 'join_game', 'Leave your current game before joining another one.');
         return;
       }
 
       const result = deps.gameManager.joinGame(gameId, socket.id, {
+        playerId: socket.data.playerId,
         userId: socket.data.authUser?.id ?? null,
       });
       if (!result) {
@@ -241,11 +242,18 @@ export function createSocketConnectionHandler(deps: SocketHandlerDeps) {
         return;
       }
 
-      const { room, color } = result;
+      const { room, color, reconnected } = result;
       socket.join(gameId);
 
       socket.emit('game_joined', { color, gameState: deps.gameManager.getClientGameState(room, socket.id) });
       socket.to(gameId).emit('game_state', deps.gameManager.getClientGameState(room, room.white || ''));
+
+      if (reconnected && room.status === 'playing') {
+        const opponentId = color === 'white' ? room.black : room.white;
+        if (opponentId) {
+          deps.io.to(opponentId).emit('opponent_reconnected');
+        }
+      }
 
       if (room.status === 'playing') {
         deps.gameManager.startClock(gameId, (updatedRoom) => {
@@ -287,7 +295,7 @@ export function createSocketConnectionHandler(deps: SocketHandlerDeps) {
         return;
       }
 
-      const gameId = deps.gameManager.getPlayerGame(socket.id);
+      const gameId = deps.gameManager.getPlayerGame(socket.data.playerId);
       if (!gameId) {
         rejectSocketEvent(deps.monitoring, socket, 'make_move', 'You are not in a game');
         return;
@@ -340,7 +348,7 @@ export function createSocketConnectionHandler(deps: SocketHandlerDeps) {
 
     socket.on('resign', () => {
       if (!enforceSocketRateLimit(socket, 'control_action', deps)) return;
-      const gameId = deps.gameManager.getPlayerGame(socket.id);
+      const gameId = deps.gameManager.getPlayerGame(socket.data.playerId);
       if (!gameId) return;
 
       const room = deps.gameManager.resign(gameId, socket.id);
@@ -369,7 +377,7 @@ export function createSocketConnectionHandler(deps: SocketHandlerDeps) {
 
     socket.on('offer_draw', () => {
       if (!enforceSocketRateLimit(socket, 'control_action', deps)) return;
-      const gameId = deps.gameManager.getPlayerGame(socket.id);
+      const gameId = deps.gameManager.getPlayerGame(socket.data.playerId);
       if (!gameId) return;
 
       const result = deps.gameManager.offerDraw(gameId, socket.id);
@@ -383,7 +391,7 @@ export function createSocketConnectionHandler(deps: SocketHandlerDeps) {
 
     socket.on('start_counting', () => {
       if (!enforceSocketRateLimit(socket, 'control_action', deps)) return;
-      const gameId = deps.gameManager.getPlayerGame(socket.id);
+      const gameId = deps.gameManager.getPlayerGame(socket.data.playerId);
       if (!gameId) return;
 
       const room = deps.gameManager.startCounting(gameId, socket.id);
@@ -395,7 +403,7 @@ export function createSocketConnectionHandler(deps: SocketHandlerDeps) {
 
     socket.on('stop_counting', () => {
       if (!enforceSocketRateLimit(socket, 'control_action', deps)) return;
-      const gameId = deps.gameManager.getPlayerGame(socket.id);
+      const gameId = deps.gameManager.getPlayerGame(socket.data.playerId);
       if (!gameId) return;
 
       const room = deps.gameManager.stopCounting(gameId, socket.id);
@@ -413,7 +421,7 @@ export function createSocketConnectionHandler(deps: SocketHandlerDeps) {
         return;
       }
 
-      const gameId = deps.gameManager.getPlayerGame(socket.id);
+      const gameId = deps.gameManager.getPlayerGame(socket.data.playerId);
       if (!gameId) return;
 
       const room = deps.gameManager.respondDraw(gameId, socket.id, payload.accept);
@@ -447,7 +455,7 @@ export function createSocketConnectionHandler(deps: SocketHandlerDeps) {
 
     socket.on('request_rematch', () => {
       if (!enforceSocketRateLimit(socket, 'control_action', deps)) return;
-      const gameId = deps.gameManager.getPlayerGame(socket.id);
+      const gameId = deps.gameManager.getPlayerGame(socket.data.playerId);
       if (!gameId) return;
 
       const room = deps.gameManager.getGame(gameId);
@@ -467,7 +475,7 @@ export function createSocketConnectionHandler(deps: SocketHandlerDeps) {
         rejectSocketEvent(deps.monitoring, socket, 'find_game', 'Invalid time control.');
         return;
       }
-      if (deps.gameManager.getBlockingPlayerGame(socket.id)) {
+      if (deps.gameManager.getBlockingPlayerGame(socket.data.playerId)) {
         rejectSocketEvent(deps.monitoring, socket, 'find_game', 'Leave your current game before entering matchmaking.');
         return;
       }
@@ -480,6 +488,7 @@ export function createSocketConnectionHandler(deps: SocketHandlerDeps) {
       logInfo('matchmaking_started', { socketId: socket.id, timeControl: payload.timeControl });
 
       deps.matchmaking.addToQueue(socket.id, payload.timeControl, {
+        playerId: socket.data.playerId,
         userId: socket.data.authUser?.id ?? null,
       });
       socket.emit('matchmaking_started');

--- a/server/src/socketHandlers.ts
+++ b/server/src/socketHandlers.ts
@@ -1,4 +1,4 @@
-import type { Server, Socket } from 'socket.io';
+import type { Socket } from 'socket.io';
 import { logInfo, logWarn } from './logger';
 import type { ServerToClientEvents, ClientToServerEvents, GameRoom, RatingChangeSummary } from '../../shared/types';
 import type { GameManager } from './gameManager';
@@ -21,7 +21,13 @@ export interface AuthenticatedSocketData {
 }
 
 type ServerSocket = Socket<ClientToServerEvents, ServerToClientEvents, Record<string, never>, AuthenticatedSocketData>;
-type IoLike = Pick<Server<ClientToServerEvents, ServerToClientEvents, Record<string, never>, AuthenticatedSocketData>, 'to'>;
+type IoLike = {
+  // eslint-disable-next-line no-unused-vars
+  to: (roomOrSocketId: string) => {
+    // eslint-disable-next-line no-unused-vars
+    emit: (...args: any[]) => unknown;
+  };
+};
 
 export const SOCKET_RATE_LIMITS = {
   create_game: { windowMs: 60 * 1000, max: 6 },

--- a/server/src/test/database-rating.test.ts
+++ b/server/src/test/database-rating.test.ts
@@ -93,6 +93,70 @@ describe('database rated game persistence', () => {
     expect(blackAfterSecond?.rated_games).toBe(1);
   });
 
+  it('applies Elo exactly once when duplicate rated saves race concurrently', async () => {
+    const database = await import('../database');
+
+    await database.initDatabase();
+
+    await database.upsertUserByEmail({
+      id: 'white-user',
+      email: 'white@example.com',
+      role: 'user',
+    });
+    await database.upsertUserByEmail({
+      id: 'black-user',
+      email: 'black@example.com',
+      role: 'user',
+    });
+
+    const payload = {
+      id: 'rated-game-race',
+      result: 'white' as const,
+      resultReason: 'checkmate',
+      whiteUserId: 'white-user',
+      blackUserId: 'black-user',
+      rated: true,
+      gameMode: 'quick_play',
+      timeControl: { initial: 300, increment: 0 },
+      moves: [],
+      finalBoard: [],
+      moveCount: 42,
+    };
+
+    vi.useRealTimers();
+    const [first, second] = await Promise.all([
+      database.saveCompletedGame(payload),
+      database.saveCompletedGame(payload),
+    ]);
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-22T00:00:00Z'));
+
+    const whiteAfter = await database.getUserById('white-user');
+    const blackAfter = await database.getUserById('black-user');
+    const savedGame = await database.getGame('rated-game-race');
+
+    expect(whiteAfter?.rating).toBe(1512);
+    expect(blackAfter?.rating).toBe(1488);
+    expect(whiteAfter?.rated_games).toBe(1);
+    expect(blackAfter?.rated_games).toBe(1);
+    expect(savedGame?.white_rating_after).toBe(1512);
+    expect(savedGame?.black_rating_after).toBe(1488);
+    expect([first.ratingChange, second.ratingChange]).toEqual([
+      {
+        whiteBefore: 1500,
+        blackBefore: 1500,
+        whiteAfter: 1512,
+        blackAfter: 1488,
+      },
+      {
+        whiteBefore: 1500,
+        blackBefore: 1500,
+        whiteAfter: 1512,
+        blackAfter: 1488,
+      },
+    ]);
+  });
+
   it('keeps mixed-auth games casual with no rating changes', async () => {
     const database = await import('../database');
 

--- a/server/src/test/gameManager.test.ts
+++ b/server/src/test/gameManager.test.ts
@@ -152,8 +152,8 @@ describe('GameManager', () => {
 
     const updatedRoom = manager.getGame(room.id);
     expect(updatedRoom?.white).toBe('white-new');
-    expect(manager.getPlayerGame('white-old')).toBeNull();
-    expect(manager.getPlayerGame('white-new')).toBe(room.id);
+    expect(manager.getPlayerGame('white-old')).toBe(room.id);
+    expect(manager.getPlayerGame('white-new')).toBeNull();
 
     const clientState = manager.getClientGameState(updatedRoom!, 'white-new');
     expect(clientState.playerColor).toBe('white');

--- a/server/src/test/matchmaking.test.ts
+++ b/server/src/test/matchmaking.test.ts
@@ -19,9 +19,9 @@ describe('MatchmakingQueue', () => {
   it('matches exact time controls immediately and tracks queue size per preset', () => {
     const queue = new MatchmakingQueue();
 
-    queue.addToQueue('socket-a', blitz);
-    queue.addToQueue('socket-b', blitz);
-    queue.addToQueue('socket-c', rapid);
+    queue.addToQueue('socket-a', blitz, { playerId: 'player-a' });
+    queue.addToQueue('socket-b', blitz, { playerId: 'player-b' });
+    queue.addToQueue('socket-c', rapid, { playerId: 'player-c' });
 
     expect(queue.getQueueSize()).toBe(3);
     expect(queue.getQueueSizeForTimeControl(blitz)).toBe(2);
@@ -32,8 +32,8 @@ describe('MatchmakingQueue', () => {
   it('falls back to flexible matching after enough wait time has passed', () => {
     const queue = new MatchmakingQueue();
 
-    queue.addToQueue('socket-a', blitz);
-    queue.addToQueue('socket-b', nearbyFlexible);
+    queue.addToQueue('socket-a', blitz, { playerId: 'player-a' });
+    queue.addToQueue('socket-b', nearbyFlexible, { playerId: 'player-b' });
 
     expect(queue.findMatch('socket-a')).toBeNull();
 
@@ -45,9 +45,9 @@ describe('MatchmakingQueue', () => {
   it('replaces an existing queue entry for the same socket and removes stale entries', () => {
     const queue = new MatchmakingQueue();
 
-    queue.addToQueue('socket-a', blitz);
-    queue.addToQueue('socket-a', rapid);
-    queue.addToQueue('socket-b', blitz);
+    queue.addToQueue('socket-a', blitz, { playerId: 'player-a' });
+    queue.addToQueue('socket-a', rapid, { playerId: 'player-a' });
+    queue.addToQueue('socket-b', blitz, { playerId: 'player-b' });
 
     expect(queue.getQueueSize()).toBe(2);
     expect(queue.getEntry('socket-a')?.timeControl).toEqual(rapid);

--- a/server/src/test/socketHandlers.test.ts
+++ b/server/src/test/socketHandlers.test.ts
@@ -13,7 +13,9 @@ const timeControl: TimeControl = { initial: 300, increment: 0 };
 type Handler = (...args: [] | [any]) => void;
 
 function createIoMock() {
-  const targets = new Map<string, { emit: ReturnType<typeof vi.fn>; emitMock: ReturnType<typeof vi.fn> }>();
+  // eslint-disable-next-line no-unused-vars
+  type IoTarget = { emit: (...args: any[]) => unknown; emitMock: ReturnType<typeof vi.fn> };
+  const targets = new Map<string, IoTarget>();
 
   return {
     targets,
@@ -21,7 +23,7 @@ function createIoMock() {
       if (!targets.has(id)) {
         const emitMock = vi.fn();
         targets.set(id, {
-          emit: emitMock,
+          emit: (...args: any[]) => emitMock(...args),
           emitMock,
         });
       }

--- a/server/src/test/socketHandlers.test.ts
+++ b/server/src/test/socketHandlers.test.ts
@@ -9,10 +9,11 @@ import type { AuthUser } from '../database';
 
 const timeControl: TimeControl = { initial: 300, increment: 0 };
 
-type Handler = (payload?: any) => void;
+// eslint-disable-next-line no-unused-vars
+type Handler = (...args: [] | [any]) => void;
 
 function createIoMock() {
-  const targets = new Map<string, { emit: (...args: any[]) => unknown; emitMock: ReturnType<typeof vi.fn> }>();
+  const targets = new Map<string, { emit: ReturnType<typeof vi.fn>; emitMock: ReturnType<typeof vi.fn> }>();
 
   return {
     targets,
@@ -20,7 +21,7 @@ function createIoMock() {
       if (!targets.has(id)) {
         const emitMock = vi.fn();
         targets.set(id, {
-          emit: (...args: any[]) => emitMock(...args),
+          emit: emitMock,
           emitMock,
         });
       }
@@ -29,7 +30,7 @@ function createIoMock() {
   };
 }
 
-function createSocketMock(id: string, authUser: AuthUser | null = null) {
+function createSocketMock(id: string, authUser: AuthUser | null = null, playerId?: string) {
   const handlers = new Map<string, Handler>();
   const roomTarget = { emit: vi.fn() };
 
@@ -37,6 +38,7 @@ function createSocketMock(id: string, authUser: AuthUser | null = null) {
     id,
     data: {
       authUser,
+      playerId: playerId ?? authUser?.id ?? id,
     },
     handshake: {
       headers: {},
@@ -76,8 +78,8 @@ describe('socket entry handlers', () => {
     ioMock = createIoMock();
   });
 
-  function connectSocket(socketId: string, authUser: AuthUser | null = null) {
-    const socket = createSocketMock(socketId, authUser);
+  function connectSocket(socketId: string, authUser: AuthUser | null = null, playerId?: string) {
+    const socket = createSocketMock(socketId, authUser, playerId);
     const handler = createSocketConnectionHandler({
       io: ioMock,
       gameManager,
@@ -257,6 +259,29 @@ describe('socket entry handlers', () => {
     socket.trigger('disconnect');
 
     expect(ioMock.to('black-socket').emitMock).toHaveBeenCalledWith('opponent_disconnected');
+  });
+
+  it('restores a disconnected player seat when the same player reconnects with a new socket id', () => {
+    const room = gameManager.createGame(timeControl, {
+      ownerSocketId: 'white-old',
+      ownerPlayerId: 'guest_white',
+      ownerColorPreference: 'white',
+    });
+    gameManager.joinGame(room.id, 'black-old', { playerId: 'guest_black' });
+
+    const disconnectedSocket = connectSocket('white-old', null, 'guest_white');
+    disconnectedSocket.trigger('disconnect');
+
+    const reconnectedSocket = connectSocket('white-new', null, 'guest_white');
+    reconnectedSocket.trigger('join_game', { gameId: room.id });
+
+    expect(reconnectedSocket.emit).toHaveBeenCalledWith(
+      'game_joined',
+      expect.objectContaining({ color: 'white' }),
+    );
+    expect(gameManager.getGame(room.id)?.white).toBe('white-new');
+    expect(gameManager.getPlayerGame('guest_white')).toBe(room.id);
+    expect(ioMock.to('black-old').emitMock).toHaveBeenCalledWith('opponent_reconnected');
   });
 
   it('emits updated counting state to both players when counting starts', () => {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -74,6 +74,8 @@ export interface GameRoom {
   id: string;
   white: string | null;  // socket id
   black: string | null;
+  whitePlayerId: string | null;
+  blackPlayerId: string | null;
   whiteUserId: string | null;
   blackUserId: string | null;
   spectators: string[];


### PR DESCRIPTION
## What does this PR do?

Brief description of the changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [X] Refactoring
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] Code compiles without errors (`npx tsc --noEmit`)
- [ ] Client builds successfully (`npm run build --workspace=client`)
- [ ] Tested locally
- [ ] No console errors in browser
