### PR TITLE
Fix rematch confirmation and stale post-game cleanup

### DIFF
--- a/client/src/components/GameOverModal.tsx
+++ b/client/src/components/GameOverModal.tsx
@@ -11,9 +11,25 @@ interface GameOverModalProps {
   onNewGame: () => void;
   onAnalyze?: () => void;
   onClose?: () => void;
+  rematchLabel?: string;
+  rematchDisabled?: boolean;
+  rematchNotice?: string | null;
 }
 
-export default function GameOverModal({ winner, reason, playerColor, rated = false, ratingChange = null, onRematch, onNewGame, onAnalyze, onClose }: GameOverModalProps) {
+export default function GameOverModal({
+  winner,
+  reason,
+  playerColor,
+  rated = false,
+  ratingChange = null,
+  onRematch,
+  onNewGame,
+  onAnalyze,
+  onClose,
+  rematchLabel,
+  rematchDisabled = false,
+  rematchNotice = null,
+}: GameOverModalProps) {
   const { t } = useTranslation();
   const isDraw = !winner;
   const isWinner = winner === playerColor;
@@ -89,6 +105,11 @@ export default function GameOverModal({ winner, reason, playerColor, rated = fal
           </div>
 
           <div className="flex flex-col gap-3">
+            {rematchNotice && (
+              <div className="rounded-lg border border-primary/20 bg-primary/10 px-3 py-2 text-center text-sm font-medium text-primary-light">
+                {rematchNotice}
+              </div>
+            )}
             {onAnalyze && (
               <button
                 onClick={onAnalyze}
@@ -99,9 +120,10 @@ export default function GameOverModal({ winner, reason, playerColor, rated = fal
             )}
             <button
               onClick={onRematch}
-              className="w-full py-3 px-6 bg-primary hover:bg-primary-light text-white font-semibold rounded-lg transition-colors"
+              disabled={rematchDisabled}
+              className="w-full py-3 px-6 bg-primary hover:bg-primary-light disabled:bg-primary/60 disabled:cursor-not-allowed text-white font-semibold rounded-lg transition-colors"
             >
-              {t('gameover.rematch')}
+              {rematchLabel ?? t('gameover.rematch')}
             </button>
             <button
               onClick={onNewGame}

--- a/client/src/components/GameOverPanel.tsx
+++ b/client/src/components/GameOverPanel.tsx
@@ -10,9 +10,24 @@ interface GameOverPanelProps {
   onRematch: () => void;
   onNewGame: () => void;
   onAnalyze?: () => void;
+  rematchLabel?: string;
+  rematchDisabled?: boolean;
+  rematchNotice?: string | null;
 }
 
-export default function GameOverPanel({ winner, reason, playerColor, rated = false, ratingChange = null, onRematch, onNewGame, onAnalyze }: GameOverPanelProps) {
+export default function GameOverPanel({
+  winner,
+  reason,
+  playerColor,
+  rated = false,
+  ratingChange = null,
+  onRematch,
+  onNewGame,
+  onAnalyze,
+  rematchLabel,
+  rematchDisabled = false,
+  rematchNotice = null,
+}: GameOverPanelProps) {
   const { t } = useTranslation();
   const isDraw = !winner;
   const isWinner = winner === playerColor;
@@ -80,6 +95,11 @@ export default function GameOverPanel({ winner, reason, playerColor, rated = fal
 
       <div className="grid gap-2 p-2.5">
         <div className="grid gap-2">
+          {rematchNotice && (
+            <div className="rounded-lg border border-primary/20 bg-primary/10 px-3 py-2 text-center text-[11px] font-medium text-primary-light">
+              {rematchNotice}
+            </div>
+          )}
           {onAnalyze && (
             <button
               onClick={onAnalyze}
@@ -91,9 +111,10 @@ export default function GameOverPanel({ winner, reason, playerColor, rated = fal
           <div className="grid grid-cols-2 gap-2">
             <button
               onClick={onRematch}
-              className="w-full py-2 px-2 bg-primary hover:bg-primary-light text-white font-semibold text-xs rounded-lg transition-colors"
+              disabled={rematchDisabled}
+              className="w-full py-2 px-2 bg-primary hover:bg-primary-light disabled:bg-primary/60 disabled:cursor-not-allowed text-white font-semibold text-xs rounded-lg transition-colors"
             >
-              {t('gameover.rematch')}
+              {rematchLabel ?? t('gameover.rematch')}
             </button>
             <button
               onClick={onNewGame}

--- a/client/src/components/GamePage.tsx
+++ b/client/src/components/GamePage.tsx
@@ -72,6 +72,7 @@ export default function GamePage() {
   const [error, setError] = useState<string | null>(null);
   const [showGuide, setShowGuide] = useState(false);
   const [showGameOverModal, setShowGameOverModal] = useState(false);
+  const [rematchState, setRematchState] = useState<'idle' | 'sent' | 'received'>('idle');
   const joinedRef = useRef(false);
   const latestGameStateRef = useRef<ClientGameState | null>(null);
 
@@ -157,6 +158,7 @@ export default function GamePage() {
       setGameState(gs);
       setGameOverInfo({ reason, winner, ratingChange });
       setShowGameOverModal(true);
+      setRematchState('idle');
       cancelPremove();
       playGameOverSound();
     };
@@ -181,11 +183,17 @@ export default function GamePage() {
       setOpponentDisconnected(false);
     };
 
+    const handleRematchOffered = () => {
+      setRematchState((current) => (current === 'sent' ? current : 'received'));
+      setShowGameOverModal(true);
+    };
+
     const handleGameCreated = ({ gameId: newGameId }: { gameId: string }) => {
       joinedRef.current = false;
       setGameState(null);
       setGameOverInfo(null);
       setShowGameOverModal(false);
+      setRematchState('idle');
       clearSelection();
       setDrawOffered(false);
       cancelPremove();
@@ -195,6 +203,7 @@ export default function GamePage() {
     };
 
     const handleError = ({ message }: { message: string }) => {
+      setRematchState('idle');
       setError(message);
     };
 
@@ -207,6 +216,7 @@ export default function GamePage() {
     socket.on('clock_update', handleClockUpdate);
     socket.on('draw_offered', handleDrawOffered);
     socket.on('draw_declined', handleDrawDeclined);
+    socket.on('rematch_offered', handleRematchOffered);
     socket.on('opponent_disconnected', handleOpponentDisconnected);
     socket.on('opponent_reconnected', handleOpponentReconnected);
     socket.on('game_created', handleGameCreated);
@@ -226,6 +236,7 @@ export default function GamePage() {
       socket.off('clock_update', handleClockUpdate);
       socket.off('draw_offered', handleDrawOffered);
       socket.off('draw_declined', handleDrawDeclined);
+      socket.off('rematch_offered', handleRematchOffered);
       socket.off('opponent_disconnected', handleOpponentDisconnected);
       socket.off('opponent_reconnected', handleOpponentReconnected);
       socket.off('game_created', handleGameCreated);
@@ -236,7 +247,7 @@ export default function GamePage() {
   useEffect(() => {
     return () => {
       const latestGameState = latestGameStateRef.current;
-      if (latestGameState?.status === 'waiting' && socket.connected) {
+      if (latestGameState && latestGameState.status !== 'playing' && socket.connected) {
         socket.emit('leave_game', { gameId: latestGameState.gameId });
       }
     };
@@ -310,6 +321,8 @@ export default function GamePage() {
   };
 
   const handleRematch = () => {
+    if (rematchState === 'sent') return;
+    setRematchState('sent');
     socket.emit('request_rematch');
   };
 
@@ -525,6 +538,16 @@ export default function GamePage() {
     : isMyTurn
       ? t('game.your_turn')
       : t('game.opponent_turn');
+  const rematchLabel = rematchState === 'received'
+    ? t('gameover.rematch_accept')
+    : rematchState === 'sent'
+      ? t('gameover.rematch_sent')
+      : t('gameover.rematch');
+  const rematchNotice = rematchState === 'received'
+    ? t('gameover.rematch_incoming')
+    : rematchState === 'sent'
+      ? t('gameover.rematch_waiting')
+      : null;
 
   return (
     <div ref={containerRef} className="bg-surface flex min-h-screen flex-col lg:h-dvh lg:overflow-hidden" tabIndex={-1}>
@@ -722,6 +745,9 @@ export default function GamePage() {
                 ratingChange={gameOverInfo.ratingChange}
                 onRematch={handleRematch}
                 onNewGame={handleNewGame}
+                rematchLabel={rematchLabel}
+                rematchDisabled={rematchState === 'sent'}
+                rematchNotice={rematchNotice}
                 onAnalyze={gameId && gameState.moveHistory.length > 0
                   ? () => navigate(savedGameAnalysisRoute(gameId))
                   : undefined
@@ -781,6 +807,9 @@ export default function GamePage() {
           ratingChange={gameOverInfo.ratingChange}
           onRematch={handleRematch}
           onNewGame={handleNewGame}
+          rematchLabel={rematchLabel}
+          rematchDisabled={rematchState === 'sent'}
+          rematchNotice={rematchNotice}
           onAnalyze={gameId && gameState && gameState.moveHistory.length > 0
             ? () => navigate(savedGameAnalysisRoute(gameId))
             : undefined

--- a/client/src/hooks/useGameSocket.ts
+++ b/client/src/hooks/useGameSocket.ts
@@ -34,6 +34,11 @@ export function useGameSocket(options: UseGameSocketOptions): UseGameSocketRetur
   const [opponentDisconnected, setOpponentDisconnected] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const joinedRef = useRef(false);
+  const latestGameStateRef = useRef<ClientGameState | null>(null);
+
+  useEffect(() => {
+    latestGameStateRef.current = gameState;
+  }, [gameState]);
 
   useEffect(() => {
     if (!gameId) return;
@@ -156,6 +161,15 @@ export function useGameSocket(options: UseGameSocketOptions): UseGameSocketRetur
       socket.off('error', handleError);
     };
   }, [gameId, navigate]);
+
+  useEffect(() => {
+    return () => {
+      const latestGameState = latestGameStateRef.current;
+      if (latestGameState && latestGameState.status !== 'playing' && socket.connected) {
+        socket.emit('leave_game', { gameId: latestGameState.gameId });
+      }
+    };
+  }, []);
 
   return {
     gameState,

--- a/client/src/lib/i18n.tsx
+++ b/client/src/lib/i18n.tsx
@@ -257,6 +257,10 @@ const EN: Record<string, string> = {
   'gameover.by_material': 'by insufficient material',
   'gameover.by_counting': 'by counting rule',
   'gameover.rematch': 'Rematch',
+  'gameover.rematch_accept': 'Accept Rematch',
+  'gameover.rematch_sent': 'Rematch Sent',
+  'gameover.rematch_waiting': 'Rematch request sent. Waiting for your opponent.',
+  'gameover.rematch_incoming': 'Your opponent wants a rematch.',
   'gameover.is_victorious': 'is victorious',
 
   // Local Game
@@ -704,6 +708,10 @@ const TH: Record<string, string> = {
   'gameover.by_material': 'ตัวหมากไม่เพียงพอ',
   'gameover.by_counting': 'โดยกฎการนับ',
   'gameover.rematch': 'แข่งอีกครั้ง',
+  'gameover.rematch_accept': 'ยอมรับแข่งอีกครั้ง',
+  'gameover.rematch_sent': 'ส่งคำขอแล้ว',
+  'gameover.rematch_waiting': 'ส่งคำขอแข่งอีกครั้งแล้ว กำลังรอคู่แข่งตอบรับ',
+  'gameover.rematch_incoming': 'คู่แข่งต้องการแข่งอีกครั้ง',
   'gameover.is_victorious': 'ชนะ',
 
   // Local Game

--- a/client/src/test/GamePage.test.tsx
+++ b/client/src/test/GamePage.test.tsx
@@ -610,9 +610,35 @@ describe('GamePage', () => {
 
     fireEvent.click(screen.getByText('panel-rematch'));
     expect(socketMock.emit).toHaveBeenCalledWith('request_rematch');
+    expect(gameOverPanelPropsMock.mock.lastCall?.[0].rematchDisabled).toBe(true);
+    expect(gameOverPanelPropsMock.mock.lastCall?.[0].rematchLabel).toBe('gameover.rematch_sent');
+
+    await act(async () => {
+      emitSocketEvent('rematch_offered', { by: 'black' });
+    });
+
+    expect(gameOverPanelPropsMock.mock.lastCall?.[0].rematchNotice).toBe('gameover.rematch_waiting');
 
     fireEvent.click(screen.getByText('panel-new-game'));
     expect(navigateMock).toHaveBeenCalledWith('/');
+  });
+
+  it('leaves finished games on unmount so stale post-game state is cleaned up', async () => {
+    const view = renderGamePage('/game/finished-room');
+
+    await act(async () => {
+      emitSocketEvent('game_joined', joinPayload({
+        gameOver: true,
+        gameId: 'finished-room',
+        status: 'finished',
+      }));
+    });
+
+    socketMock.emit.mockClear();
+    socketMock.connected = true;
+    view.unmount();
+
+    expect(socketMock.emit).toHaveBeenCalledWith('leave_game', { gameId: 'finished-room' });
   });
 
   it('recovers from server errors, toggles the piece guide, and handles game replacement', async () => {

--- a/client/src/test/useGameSocket.test.tsx
+++ b/client/src/test/useGameSocket.test.tsx
@@ -203,6 +203,34 @@ describe('useGameSocket', () => {
     expect(result.current.error).toBe('rate limited');
   });
 
+  it('leaves non-live games on unmount to clear stale socket state', async () => {
+    const { unmount } = renderHook(() => useGameSocket({ gameId: 'room-finished' }), { wrapper });
+
+    act(() => {
+      emitSocketEvent('game_joined', {
+        color: 'white',
+        gameState: {
+          ...createInitialGameState(300_000, 300_000),
+          gameMode: 'private',
+          rated: false,
+          status: 'finished',
+          gameOver: true,
+          playerColor: 'white',
+          drawOffer: null,
+          gameId: 'room-finished',
+          whitePlayerName: 'White',
+          blackPlayerName: 'Black',
+        },
+      });
+    });
+
+    socketMock.connected = true;
+    socketMock.emit.mockClear();
+    unmount();
+
+    expect(socketMock.emit).toHaveBeenCalledWith('leave_game', { gameId: 'room-finished' });
+  });
+
   it('handles transition, sound, timing, draw, game-over, and replacement events', async () => {
     const initialState = createInitialGameState(300_000, 300_000);
     const waitingState = {

--- a/server/src/gameManager.ts
+++ b/server/src/gameManager.ts
@@ -9,6 +9,7 @@ export class GameManager {
   private games: Map<string, GameRoom> = new Map();
   private playerGames: Map<string, string> = new Map(); // playerId -> gameId
   private socketGames: Map<string, string> = new Map(); // socketId -> gameId
+  private rematchOffers: Map<string, PieceColor> = new Map(); // gameId -> offering color
   private clockIntervals: Map<string, ReturnType<typeof setInterval>> = new Map();
   private disconnectedPlayers: Map<string, number> = new Map();
   private roomLastActivity: Map<string, number> = new Map();
@@ -298,6 +299,8 @@ export class GameManager {
   createRematch(gameId: string): GameRoom | null {
     const oldRoom = this.games.get(gameId);
     if (!oldRoom || oldRoom.status !== 'finished') return null;
+    if (!oldRoom.white || !oldRoom.black) return null;
+    if (!oldRoom.whitePlayerId || !oldRoom.blackPlayerId) return null;
 
     const newRoom = this.createGame(oldRoom.timeControl);
     // Swap colors for rematch
@@ -326,6 +329,44 @@ export class GameManager {
     return newRoom;
   }
 
+  requestRematch(gameId: string, socketId: string): {
+    kind: 'offered' | 'accepted' | 'duplicate' | 'unavailable';
+    by: PieceColor;
+    opponentSocketId: string | null;
+    room?: GameRoom;
+  } | null {
+    const room = this.games.get(gameId);
+    if (!room || room.status !== 'finished') return null;
+
+    const playerColor = this.getPlayerColor(room, socketId);
+    if (!playerColor) return null;
+
+    const opponentColor: PieceColor = playerColor === 'white' ? 'black' : 'white';
+    const opponentSocketId = opponentColor === 'white' ? room.white : room.black;
+    if (!opponentSocketId) {
+      this.rematchOffers.delete(gameId);
+      return { kind: 'unavailable', by: playerColor, opponentSocketId: null };
+    }
+
+    const existingOffer = this.rematchOffers.get(gameId);
+    if (existingOffer === playerColor) {
+      return { kind: 'duplicate', by: playerColor, opponentSocketId };
+    }
+
+    if (existingOffer === opponentColor) {
+      this.rematchOffers.delete(gameId);
+      const newRoom = this.createRematch(gameId);
+      if (!newRoom) {
+        return { kind: 'unavailable', by: playerColor, opponentSocketId };
+      }
+      return { kind: 'accepted', by: playerColor, opponentSocketId, room: newRoom };
+    }
+
+    this.rematchOffers.set(gameId, playerColor);
+    this.touchGame(gameId);
+    return { kind: 'offered', by: playerColor, opponentSocketId };
+  }
+
   handleDisconnect(socketId: string): { gameId: string; color: PieceColor } | null {
     const gameId = this.socketGames.get(socketId);
     if (!gameId) return null;
@@ -336,6 +377,7 @@ export class GameManager {
     const color = this.getPlayerColor(room, socketId);
     this.socketGames.delete(socketId);
     room.spectators = room.spectators.filter((spectatorId) => spectatorId !== socketId);
+    this.rematchOffers.delete(gameId);
 
     if (color) {
       this.disconnectedPlayers.set(this.getDisconnectedKey(gameId, color), Date.now());
@@ -436,28 +478,40 @@ export class GameManager {
     }
 
     const playerColor = this.getPlayerColor(room, socketId);
-    if (room.status !== 'waiting' && playerColor) {
+    if (room.status === 'playing' && playerColor) {
       return null;
     }
 
-    if (room.white === socketId) {
-      if (room.whitePlayerId) {
-        this.playerGames.delete(room.whitePlayerId);
-      }
+    const leavingWhite = room.white === socketId;
+    const leavingBlack = room.black === socketId;
+
+    if (leavingWhite && room.whitePlayerId) {
+      this.playerGames.delete(room.whitePlayerId);
+    }
+    if (leavingBlack && room.blackPlayerId) {
+      this.playerGames.delete(room.blackPlayerId);
+    }
+
+    if (leavingWhite) {
       room.white = null;
+    }
+    if (leavingBlack) {
+      room.black = null;
+    }
+
+    if (room.status === 'waiting' && leavingWhite) {
       room.whitePlayerId = null;
       room.whiteUserId = null;
+      room.whitePlayerName = null;
     }
-    if (room.black === socketId) {
-      if (room.blackPlayerId) {
-        this.playerGames.delete(room.blackPlayerId);
-      }
-      room.black = null;
+    if (room.status === 'waiting' && leavingBlack) {
       room.blackPlayerId = null;
       room.blackUserId = null;
+      room.blackPlayerName = null;
     }
     room.spectators = room.spectators.filter((spectatorId) => spectatorId !== socketId);
     this.socketGames.delete(socketId);
+    this.rematchOffers.delete(gameId);
     this.touchGame(gameId);
 
     const shouldDelete = room.status === 'waiting' && !room.white && !room.black && room.spectators.length === 0;
@@ -594,6 +648,7 @@ export class GameManager {
   private deleteGame(gameId: string, room: GameRoom): void {
     this.games.delete(gameId);
     this.stopClock(gameId);
+    this.rematchOffers.delete(gameId);
     this.roomLastActivity.delete(gameId);
     this.clearDisconnectedPlayer(gameId, 'white');
     this.clearDisconnectedPlayer(gameId, 'black');

--- a/server/src/socketHandlers.ts
+++ b/server/src/socketHandlers.ts
@@ -484,10 +484,26 @@ export function createSocketConnectionHandler(deps: SocketHandlerDeps) {
       const gameId = deps.gameManager.getPlayerGame(socket.data.playerId);
       if (!gameId) return;
 
-      const room = deps.gameManager.getGame(gameId);
-      if (!room) return;
+      const rematchResult = deps.gameManager.requestRematch(gameId, socket.id);
+      if (!rematchResult) return;
 
-      const newRoom = deps.gameManager.createRematch(gameId);
+      if (rematchResult.kind === 'duplicate') {
+        return;
+      }
+
+      if (rematchResult.kind === 'unavailable') {
+        rejectSocketEvent(deps.monitoring, socket, 'request_rematch', 'Your opponent already left the finished game.');
+        return;
+      }
+
+      if (rematchResult.kind === 'offered') {
+        if (rematchResult.opponentSocketId) {
+          deps.io.to(rematchResult.opponentSocketId).emit('rematch_offered', { by: rematchResult.by });
+        }
+        return;
+      }
+
+      const newRoom = rematchResult.room;
       if (!newRoom) return;
 
       if (newRoom.white) deps.io.to(newRoom.white).emit('game_created', { gameId: newRoom.id });

--- a/server/src/test/gameManager.test.ts
+++ b/server/src/test/gameManager.test.ts
@@ -96,6 +96,44 @@ describe('GameManager', () => {
     expect(manager.createRematch(room.id)).toBeNull();
   });
 
+  it('stores a rematch offer until the opponent explicitly accepts it', () => {
+    const manager = new GameManager();
+    const room = manager.createGame(timeControl);
+    manager.joinGame(room.id, 'white-socket');
+    manager.joinGame(room.id, 'black-socket');
+    manager.resign(room.id, 'white-socket');
+
+    const offered = manager.requestRematch(room.id, 'white-socket');
+    expect(offered).toEqual({
+      kind: 'offered',
+      by: 'white',
+      opponentSocketId: 'black-socket',
+    });
+
+    const accepted = manager.requestRematch(room.id, 'black-socket');
+    expect(accepted?.kind).toBe('accepted');
+    expect(accepted?.room?.white).toBe('black-socket');
+    expect(accepted?.room?.black).toBe('white-socket');
+    expect(accepted?.room?.status).toBe('playing');
+  });
+
+  it('treats rematch offers as unavailable once the opponent leaves the finished game', () => {
+    const manager = new GameManager();
+    const room = manager.createGame(timeControl);
+    manager.joinGame(room.id, 'white-socket');
+    manager.joinGame(room.id, 'black-socket');
+    manager.resign(room.id, 'white-socket');
+
+    manager.requestRematch(room.id, 'white-socket');
+    manager.leaveGame('white-socket', room.id);
+
+    expect(manager.requestRematch(room.id, 'black-socket')).toEqual({
+      kind: 'unavailable',
+      by: 'black',
+      opponentSocketId: null,
+    });
+  });
+
   it('cleans up stale waiting, finished, and disconnected games', () => {
     const manager = new GameManager();
 

--- a/server/src/test/socketHandlers.test.ts
+++ b/server/src/test/socketHandlers.test.ts
@@ -252,6 +252,51 @@ describe('socket entry handlers', () => {
     expect(ioMock.targets.size).toBe(0);
   });
 
+  it('requires explicit confirmation from both players before creating a rematch', () => {
+    const room = gameManager.createGame(timeControl);
+    gameManager.joinGame(room.id, 'white-socket');
+    gameManager.joinGame(room.id, 'black-socket');
+    gameManager.resign(room.id, 'white-socket');
+
+    const whiteSocket = connectSocket('white-socket');
+    const blackSocket = connectSocket('black-socket');
+
+    whiteSocket.trigger('request_rematch');
+
+    expect(ioMock.to('black-socket').emitMock).toHaveBeenCalledWith('rematch_offered', { by: 'white' });
+    expect(ioMock.to('white-socket').emitMock).not.toHaveBeenCalledWith('game_created', expect.anything());
+    expect(ioMock.to('black-socket').emitMock).not.toHaveBeenCalledWith('game_created', expect.anything());
+
+    blackSocket.trigger('request_rematch');
+
+    expect(ioMock.to('white-socket').emitMock).toHaveBeenCalledWith('game_created', { gameId: expect.any(String) });
+    expect(ioMock.to('black-socket').emitMock).toHaveBeenCalledWith('game_created', { gameId: expect.any(String) });
+  });
+
+  it('clears pending rematch offers when a player leaves a finished game', () => {
+    const room = gameManager.createGame(timeControl);
+    gameManager.joinGame(room.id, 'white-socket');
+    gameManager.joinGame(room.id, 'black-socket');
+    gameManager.resign(room.id, 'white-socket');
+
+    const whiteSocket = connectSocket('white-socket');
+    const blackSocket = connectSocket('black-socket');
+
+    whiteSocket.trigger('request_rematch');
+    whiteSocket.emit.mockClear();
+
+    whiteSocket.trigger('leave_game', { gameId: room.id });
+
+    expect(whiteSocket.emit).toHaveBeenCalledWith('game_left', { gameId: room.id });
+    expect(gameManager.getPlayerGame('white-socket')).toBeNull();
+
+    blackSocket.trigger('request_rematch');
+
+    expect(blackSocket.emit).toHaveBeenCalledWith('error', { message: 'Your opponent already left the finished game.' });
+    expect(ioMock.to('white-socket').emitMock).not.toHaveBeenCalledWith('game_created', expect.anything());
+    expect(ioMock.to('black-socket').emitMock).not.toHaveBeenCalledWith('game_created', expect.anything());
+  });
+
   it('notifies the opponent on disconnect from a live game', () => {
     const room = gameManager.createGame(timeControl);
     gameManager.joinGame(room.id, 'white-socket');


### PR DESCRIPTION
## What does this PR do?

Brief description of the changes.

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] Code compiles without errors (`npx tsc --noEmit`)
- [ ] Client builds successfully (`npm run build --workspace=client`)
- [ ] Tested locally
- [ ] No console errors in browser
