### PR TITLE
Stop loading full English catalog on the home route

### DIFF
--- a/client/e2e/home.spec.ts
+++ b/client/e2e/home.spec.ts
@@ -28,7 +28,8 @@ test.describe('Homepage', () => {
   test('navigates to quick play', async ({ page }) => {
     await page.locator('#main-content').getByRole('button', { name: /find opponent/i }).click();
     await expect(page).toHaveURL('/quick-play');
-    await expect(page.getByRole('heading', { name: /quick play/i })).toBeVisible();
+    await expect(page.getByText(/^time control$/i)).toBeVisible();
+    await expect(page.getByRole('button', { name: /5\+0/i })).toBeVisible();
   });
 
   test('navigates to local game', async ({ page }) => {

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,10 +1,11 @@
 import { lazy, Suspense, useEffect, useState } from 'react';
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, useLocation } from 'react-router-dom';
 import HomePage from './components/HomePage';
 import { scheduleOnUserIntent } from './lib/defer';
 import { loadBotGameRoute, loadLocalGameRoute, loadQuickPlayRoute } from './lib/routePrefetch';
 import { routes } from './lib/routes';
 import { SeoHeadManager } from './lib/seo';
+import { useTranslation } from './lib/i18n';
 
 // Lazy load route components for code splitting
 const GamePage = lazy(() => import('./components/GamePage'));
@@ -45,6 +46,19 @@ function isAutomatedBrowser() {
   return typeof navigator !== 'undefined' && navigator.webdriver;
 }
 
+function RouteTranslationLoader() {
+  const location = useLocation();
+  const { lang, setLang } = useTranslation();
+
+  useEffect(() => {
+    if (lang === 'en' && location.pathname !== routes.home) {
+      setLang('en');
+    }
+  }, [lang, location.pathname, setLang]);
+
+  return null;
+}
+
 export default function App() {
   const [showFeedbackWidget, setShowFeedbackWidget] = useState(
     import.meta.env.MODE === 'test' && !isAutomatedBrowser(),
@@ -65,6 +79,7 @@ export default function App() {
         Skip to main content
       </a>
       <Suspense fallback={<RouteFallback />}>
+        <RouteTranslationLoader />
         <Routes>
           <Route path={routes.home} element={<HomePage />} />
           <Route path={routes.liveGamePattern} element={<GamePage />} />

--- a/client/src/lib/i18n.tsx
+++ b/client/src/lib/i18n.tsx
@@ -256,46 +256,19 @@ export function I18nProvider({ children }: { children: ReactNode }) {
   }, [lang]);
 
   useEffect(() => {
-    if (lang !== 'en' || fullEnglishLoaded) {
+    if (lang !== 'en' || fullEnglishLoaded || !shouldEagerlyLoadEnglish) {
       return;
     }
 
     let cancelled = false;
-    let idleId: number | undefined;
-    let timeoutId: number | undefined;
 
-    const loadEnglish = () => {
-      void ensureTranslations('en').then(() => {
-        if (cancelled) return;
-        setCatalogVersion((version) => version + 1);
-      });
-    };
-
-    const pathname = typeof window !== 'undefined' ? window.location.pathname : '/';
-    const shouldLoadImmediately = shouldEagerlyLoadEnglish || pathname !== '/';
-
-    if (shouldLoadImmediately || typeof window === 'undefined') {
-      loadEnglish();
-      return () => {
-        cancelled = true;
-      };
-    }
-
-    const requestIdle = window.requestIdleCallback;
-    if (typeof requestIdle === 'function') {
-      idleId = requestIdle(loadEnglish, { timeout: 1200 });
-    } else {
-      timeoutId = window.setTimeout(loadEnglish, 300);
-    }
+    void ensureTranslations('en').then(() => {
+      if (cancelled) return;
+      setCatalogVersion((version) => version + 1);
+    });
 
     return () => {
       cancelled = true;
-      if (idleId !== undefined) {
-        window.cancelIdleCallback?.(idleId);
-      }
-      if (timeoutId !== undefined) {
-        window.clearTimeout(timeoutId);
-      }
     };
   }, [lang]);
 


### PR DESCRIPTION
## What does this PR do?

Brief description of the changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] Code compiles without errors (`npx tsc --noEmit`)
- [ ] Client builds successfully (`npm run build --workspace=client`)
- [ ] Tested locally
- [ ] No console errors in browser
