### PR TITLE
feat: add Zod environment validation at server startup

### DIFF
--- a/server/src/env.ts
+++ b/server/src/env.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { validateServerEnv } from '../../shared/validation';
 
 let loaded = false;
 
@@ -57,3 +58,13 @@ export function loadProjectEnv(): void {
 }
 
 loadProjectEnv();
+
+/**
+ * Validate environment variables at startup
+ * This ensures all required env vars are present and valid
+ * Fails fast with clear error messages if configuration is invalid
+ */
+const env = validateServerEnv(process.env);
+
+// Export validated environment for use throughout the application
+export { env };


### PR DESCRIPTION
Integrate validateServerEnv() into server/src/env.ts to validate environment variables at startup. This provides:

- Type-safe environment variables through Zod schema inference
- Clear error messages on startup if required env vars are missing
- Default values for optional configuration (PORT, NODE_ENV)
- Validation constraints (PORT must be 1-65535, etc.)

The validation runs immediately after .env files are loaded, ensuring all environment configuration is valid before the server starts accepting connections.

## What does this PR do?

Brief description of the changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] Code compiles without errors (`npx tsc --noEmit`)
- [ ] Client builds successfully (`npm run build --workspace=client`)
- [ ] Tested locally
- [ ] No console errors in browser
