### PR TITLE
feat: integrate Zod validation into puzzle import pipeline

### DIFF
--- a/shared/puzzleSourceImport.ts
+++ b/shared/puzzleSourceImport.ts
@@ -2,6 +2,7 @@ import { createInitialBoard } from './engine';
 import type { Board, Move, PieceColor } from './types';
 import type { PuzzleGenerationSource } from './puzzleGeneration';
 import { validateMakrukReplay } from './makrukPositionValidation';
+import { PuzzleGenerationSourceSchema } from './validation/puzzle';
 
 interface ParsedHeaders {
   id?: string;
@@ -47,6 +48,26 @@ function buildSource(headers: ParsedHeaders, moves: Move[], index: number): Puzz
   };
 }
 
+/**
+ * Validates a puzzle generation source using Zod schema.
+ * Returns null if validation fails, logging errors for debugging.
+ */
+function validateSource(source: PuzzleGenerationSource, index: number): PuzzleGenerationSource | null {
+  const result = PuzzleGenerationSourceSchema.safeParse(source);
+  
+  if (!result.success) {
+    const errors = result.error.issues.map(issue => {
+      const path = issue.path.join('.');
+      return path ? `${path}: ${issue.message}` : issue.message;
+    });
+    
+    console.warn(`[PuzzleImport] Source ${source.id ?? index} validation failed:`, errors.join(', '));
+    return null;
+  }
+  
+  return result.data;
+}
+
 export function parsePgnLikePuzzleSources(raw: string): PuzzleGenerationSource[] {
   const sources: PuzzleGenerationSource[] = [];
   const lines = raw.split(/\r?\n/);
@@ -60,7 +81,12 @@ export function parsePgnLikePuzzleSources(raw: string): PuzzleGenerationSource[]
       .filter((move): move is Move => move !== null);
 
     if (parsedMoves.length > 0) {
-      sources.push(buildSource(headers, parsedMoves, sources.length));
+      const source = buildSource(headers, parsedMoves, sources.length);
+      const validatedSource = validateSource(source, sources.length);
+      
+      if (validatedSource) {
+        sources.push(validatedSource);
+      }
     }
 
     headers = {};

--- a/shared/validation/puzzle.ts
+++ b/shared/validation/puzzle.ts
@@ -147,6 +147,46 @@ export const PuzzleSchema = z.object({
 export type Puzzle = z.infer<typeof PuzzleSchema>;
 
 /**
+ * Puzzle Generation Source Schema
+ * 
+ * Validates puzzle generation sources at import/generation time.
+ * This is a lighter-weight schema for sources before they become full puzzles.
+ */
+export const PuzzleGenerationSourceSchema = z.object({
+  id: z.string().min(1),
+  source: z.string().min(1),
+  moves: z.array(z.object({
+    from: z.object({
+      row: z.number().int().min(0).max(7),
+      col: z.number().int().min(0).max(7),
+    }),
+    to: z.object({
+      row: z.number().int().min(0).max(7),
+      col: z.number().int().min(0).max(7),
+    }),
+  })),
+  initialBoard: BoardSchema.optional(),
+  startingTurn: PieceColorSchema.optional(),
+  setupMoves: z.array(z.object({
+    from: z.object({
+      row: z.number().int().min(0).max(7),
+      col: z.number().int().min(0).max(7),
+    }),
+    to: z.object({
+      row: z.number().int().min(0).max(7),
+      col: z.number().int().min(0).max(7),
+    }),
+  })).optional(),
+  positionSourceType: z.enum(['real-game', 'engine-generated', 'constructed']).optional(),
+  startingPlyNumber: z.number().int().min(1).optional(),
+  moveCount: z.number().int().min(0).optional(),
+  result: z.string().optional(),
+  resultReason: z.string().optional(),
+});
+
+export type PuzzleGenerationSource = z.infer<typeof PuzzleGenerationSourceSchema>;
+
+/**
  * Validates a puzzle object at runtime.
  * Returns the validated puzzle or throws a ZodError with detailed messages.
  */


### PR DESCRIPTION
Add runtime validation to puzzle source import using Zod schemas:

- Create PuzzleGenerationSourceSchema in validation/puzzle.ts
  - Validates all fields of PuzzleGenerationSource
  - Includes proper types for moves, boards, and metadata
  - Exports inferred type for TypeScript compatibility

- Integrate validation into puzzleSourceImport.ts:
  - Add validateSource() helper that uses safeParse
  - Filter out invalid sources during PGN parsing
  - Log validation errors with field paths for debugging
  - Continue processing other sources if one fails

Benefits:
- Invalid puzzle sources are caught immediately at import
- Clear error messages show exactly which fields are wrong
- Prevents bad data from entering the generation pipeline
- Graceful degradation - one bad source doesn't block others

Follows Zod best practices:
- safeParse for non-throwing validation
- Detailed error messages with field paths
- Type inference for seamless TypeScript integration

## What does this PR do?

Brief description of the changes.

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] Code compiles without errors (`npx tsc --noEmit`)
- [ ] Client builds successfully (`npm run build --workspace=client`)
- [ ] Tested locally
- [ ] No console errors in browser
