### PR TITLE
feat: add Zod schema validation to puzzle generation pipeline

### DIFF
--- a/shared/puzzleGeneration.ts
+++ b/shared/puzzleGeneration.ts
@@ -12,6 +12,8 @@ import { validatePuzzle } from './puzzleValidation';
 import { finalizePuzzle } from './puzzleCatalog';
 import { isMateTheme, isPromotionTheme, isTacticalTheme } from './puzzleThemes';
 import { derivePuzzleTags, estimatePuzzleDifficultyScore, isMiddlegameRichBoard } from './puzzleMetadata';
+import { PuzzleSchema } from './validation/puzzle';
+import { isValidPuzzle } from './puzzlePipelineValidation';
 
 export interface PuzzleGenerationSource {
   id: string;
@@ -1039,6 +1041,13 @@ export function generatePuzzleCandidateDraftsFromMoveSequence(
       );
       puzzle.id = draft.id;
 
+      // Stage 1: Zod schema validation (structure and types)
+      if (!isValidPuzzle(puzzle)) {
+        console.warn(`[PuzzleGeneration] Puzzle ${draft.id} failed schema validation`);
+        continue;
+      }
+
+      // Stage 2: Business logic validation (mate detection, legal moves, etc.)
       const result = validatePuzzle(puzzle);
       if (result.errors.length > 0) continue;
 


### PR DESCRIPTION
Integrate Zod validation into the puzzle generation process to catch structural issues before business logic validation:

- Import PuzzleSchema and isValidPuzzle from validation modules
- Add two-stage validation in generatePuzzleCandidateDraftsFromMoveSequence():
  1. Zod schema validation (structure and types)
  2. Business logic validation (mate detection, legal moves, etc.)
- Log schema validation failures for debugging generation issues
- Skip invalid puzzles early to save processing time

Benefits:
- Catches structural issues immediately (missing fields, wrong types)
- Provides clearer separation between schema and business logic errors
- Prevents invalid data from reaching the review queue
- Maintains existing validation behavior while adding safety layer

All 75 server tests pass.

## What does this PR do?

Brief description of the changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] Code compiles without errors (`npx tsc --noEmit`)
- [ ] Client builds successfully (`npm run build --workspace=client`)
- [ ] Tested locally
- [ ] No console errors in browser
