### PR TITLE
feat: migrate AnalysisPage to TanStack Query

### DIFF
--- a/client/src/components/AnalysisPage.tsx
+++ b/client/src/components/AnalysisPage.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
 import type { Position, PieceColor, Move, Board as BoardType, GameState } from '@shared/types';
 import { createInitialBoard, posToAlgebraic } from '@shared/engine';
 import {
@@ -28,14 +29,7 @@ import PieceSVG from './PieceSVG';
 import Header from './Header';
 import PostGameReviewPanel from './PostGameReviewPanel';
 import type { WorkerResponse } from '../workers/analysisWorker';
-
-interface GameData {
-  id: string;
-  moves: Move[];
-  result: string;
-  resultReason: string;
-  moveCount: number;
-}
+import { gameQueryOptions, type GameAnalysisData } from '../queries/analysis';
 
 type AnalysisMode = 'game' | 'editor';
 type EditorTool = 'erase' | 'move' | `${'white' | 'black'}:${'K' | 'M' | 'S' | 'R' | 'N' | 'P' | 'PM'}`;
@@ -52,7 +46,15 @@ export default function AnalysisPage() {
   const { t } = useTranslation();
   const reviewT = useReviewCopy();
 
-  const [gameData, setGameData] = useState<GameData | null>(null);
+  // TanStack Query for fetching game data from API
+  const {
+    data: apiGameData,
+    isLoading: isLoadingApi,
+    isError: isApiError,
+    error: apiError,
+  } = useQuery(gameQueryOptions(gameId));
+
+  const [gameData, setGameData] = useState<GameAnalysisData | null>(null);
   const [mode, setMode] = useState<AnalysisMode>('game');
   const [analysis, setAnalysis] = useState<GameAnalysis | null>(null);
   const [analyzing, setAnalyzing] = useState(false);
@@ -151,34 +153,12 @@ export default function AnalysisPage() {
 
     if (gameId) {
       setMode('game');
-      fetch(`/api/game/${gameId}`)
-        .then(r => {
-          if (!r.ok) throw new Error(t('analysis.game_not_found'));
-          return r.json();
-        })
-        .then(data => {
-          if (data.moves) {
-            setGameData({
-              id: data.id,
-              moves: data.moves,
-              result: data.result || data.status,
-              resultReason: data.resultReason || '',
-              moveCount: data.moveCount || data.moves.length,
-            });
-          } else {
-            setError(t('analysis.no_moves'));
-          }
-          setLoading(false);
-        })
-        .catch(() => {
-          setError(t('analysis.game_not_found'));
-          setLoading(false);
-        });
+      // Data will be set by the apiGameData effect below
     } else {
       setMode('editor');
       setLoading(false);
     }
-  }, [gameId, searchParams, t]);
+  }, [gameId, searchParams, t, isLoadingApi, isApiError]);
 
   useEffect(() => {
     return () => {
@@ -186,6 +166,37 @@ export default function AnalysisPage() {
       workerRef.current = null;
     };
   }, []);
+
+  // Handle API game data from TanStack Query
+  useEffect(() => {
+    if (!gameId || mode !== 'game') return;
+
+    if (isLoadingApi) {
+      setLoading(true);
+      return;
+    }
+
+    if (isApiError) {
+      setError(t('analysis.game_not_found'));
+      setLoading(false);
+      return;
+    }
+
+    if (apiGameData) {
+      if (apiGameData.moves) {
+        setGameData({
+          id: apiGameData.id,
+          moves: apiGameData.moves,
+          result: apiGameData.result || apiGameData.status || 'unknown',
+          resultReason: apiGameData.resultReason || '',
+          moveCount: apiGameData.moveCount || apiGameData.moves.length,
+        });
+      } else {
+        setError(t('analysis.no_moves'));
+      }
+      setLoading(false);
+    }
+  }, [gameId, mode, apiGameData, isLoadingApi, isApiError, t]);
 
   // Run analysis when game data is loaded
   useEffect(() => {
@@ -1515,7 +1526,7 @@ function findCheckSquare(state: GameState): Position | null {
   return null;
 }
 
-function getAnalysisCacheKey(gameData: GameData, movetimeMs: number): string {
+function getAnalysisCacheKey(gameData: GameAnalysisData, movetimeMs: number): string {
   return `analysis-cache:${ANALYSIS_CACHE_VERSION}:${gameData.id}:${movetimeMs}:${gameData.moves.length}`;
 }
 

--- a/client/src/queries/analysis.ts
+++ b/client/src/queries/analysis.ts
@@ -1,0 +1,44 @@
+import { queryOptions } from '@tanstack/react-query';
+import type { Move } from '@shared/types';
+
+export interface GameAnalysisData {
+  id: string;
+  moves: Move[];
+  result: string;
+  resultReason: string;
+  moveCount: number;
+}
+
+export interface GameApiResponse {
+  id: string;
+  moves: Move[];
+  result?: string;
+  status?: string;
+  resultReason?: string;
+  moveCount?: number;
+}
+
+// API function
+async function fetchGame(gameId: string): Promise<GameApiResponse> {
+  const response = await fetch(`/api/game/${gameId}`);
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch game');
+  }
+
+  return response.json();
+}
+
+// Query options factory
+export function gameQueryOptions(gameId: string | undefined) {
+  return queryOptions({
+    queryKey: ['game', gameId],
+    queryFn: () => {
+      if (!gameId) throw new Error('Game ID is required');
+      return fetchGame(gameId);
+    },
+    enabled: Boolean(gameId),
+    staleTime: 1000 * 60 * 5, // Game data stays fresh for 5 minutes
+    gcTime: 1000 * 60 * 10, // Keep in cache for 10 minutes
+  });
+}

--- a/client/src/queries/index.ts
+++ b/client/src/queries/index.ts
@@ -1,4 +1,5 @@
 // Export all query options
+export * from './analysis';
 export * from './games';
 export * from './leaderboard';
 export * from './stats';


### PR DESCRIPTION
## Summary

Migrated AnalysisPage from manual fetch to TanStack Query for better caching and data management.

## Changes

- **New file:**  - Query options for game analysis data
- **Modified:**  - Replaced manual fetch with useQuery
- **Modified:**  - Added analysis exports

## Benefits

- **Caching:** Game data cached for 5 minutes (staleTime)
- **Background refetching:** Data stays fresh when users revisit
- **Error handling:** Consistent error states via isError/error
- **Loading states:** Better loading UX with isLoading
- **Type safety:** Full TypeScript support

## Testing

✅ All 307 tests pass
✅ Editor mode still works (no API calls)
✅ Local/inline payload modes still work
✅ API mode now uses TanStack Query

## Migration Pattern

This follows the same pattern established in:
- GamesPage (games list)
- LeaderboardPage (leaderboard)
- HomePage (stats)

---

Ready for review! 🚀