### PR TITLE
security: add rate limiting to missing socket events

### DIFF
--- a/server/src/socketHandlers.ts
+++ b/server/src/socketHandlers.ts
@@ -121,6 +121,8 @@ function emitGameOverToParticipants(
 export const SOCKET_RATE_LIMITS = {
   create_game: { windowMs: 60 * 1000, max: 6 },
   join_game: { windowMs: 60 * 1000, max: 20 },
+  leave_game: { windowMs: 60 * 1000, max: 30 },
+  cancel_matchmaking: { windowMs: 60 * 1000, max: 20 },
   find_game: { windowMs: 60 * 1000, max: 10 },
   find_game_ip: { windowMs: 60 * 1000, max: 30 },
   make_move: { windowMs: 10 * 1000, max: 40 },
@@ -333,6 +335,8 @@ export function createSocketConnectionHandler(deps: SocketHandlerDeps) {
     });
 
     socket.on('leave_game', (payload) => {
+      if (!enforceSocketRateLimit(socket, 'leave_game', deps, ['socket', 'ip'])) return;
+      
       if (payload?.gameId !== undefined && !isValidGameId(payload.gameId)) {
         deps.monitoring.increment('socket.invalidPayload');
         rejectSocketEvent(deps.monitoring, socket, 'leave_game', 'Invalid game ID.');
@@ -658,6 +662,8 @@ export function createSocketConnectionHandler(deps: SocketHandlerDeps) {
     });
 
     socket.on('cancel_matchmaking', () => {
+      if (!enforceSocketRateLimit(socket, 'cancel_matchmaking', deps, ['socket', 'ip'])) return;
+      
       const removed = deps.matchmaking.removeFromQueue(socket.id);
       if (removed) {
         logInfo('matchmaking_cancelled', { socketId: socket.id });


### PR DESCRIPTION
Add rate limiting to previously unprotected socket events:
- leave_game: 30 per minute (socket + IP)
- cancel_matchmaking: 20 per minute (socket + IP)

Also adds these events to SOCKET_RATE_LIMITS constant.

Prevents spam attacks on game leave/join and matchmaking queue manipulation.

All existing rate limits remain unchanged:
- create_game: 6/min
- join_game: 20/min
- find_game: 10/min
- make_move: 40/10sec
- control_action: 15/30sec
- presence_heartbeat: 90/min

Refs: security hardening - socket event rate limiting

## What does this PR do?

Brief description of the changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] Code compiles without errors (`npx tsc --noEmit`)
- [ ] Client builds successfully (`npm run build --workspace=client`)
- [ ] Tested locally
- [ ] No console errors in browser
