### PR TITLE
fix: persist bot games to database for reliable analysis access

### DIFF
--- a/client/src/components/AnalysisPage.tsx
+++ b/client/src/components/AnalysisPage.tsx
@@ -150,6 +150,15 @@ export default function AnalysisPage() {
       return;
     }
 
+    // Check if gameId is an inline source that requires sessionStorage data
+    const inlineSources = ['bot', 'local'];
+    if (gameId && inlineSources.includes(gameId)) {
+      // Inline source but no sessionStorage data - show session expired error
+      setError(t('analysis.session_expired'));
+      setLoading(false);
+      return;
+    }
+
     if (gameId) {
       setMode('game');
       // Data will be set by the apiGameData effect below

--- a/client/src/components/BotGame.tsx
+++ b/client/src/components/BotGame.tsx
@@ -156,6 +156,44 @@ export default function BotGame() {
   const botName = selectedBot.name;
   const setupIntroPreview = getBotDialoguePack(selectedBot, lang).intro[0] ?? selectedBot.flavorIntroLine;
 
+  // Helper to save bot game and navigate to analysis
+  const handleAnalyzeGame = useCallback(() => {
+    if (!currentGameId || gameState.moveHistory.length === 0) {
+      navigate('/analysis');
+      return;
+    }
+
+    const gameResult: import('../queries/botGames').BotGameResult = {
+      id: currentGameId,
+      playerColor,
+      playerName: playerDisplayName,
+      level: botLevel,
+      botId: selectedBotId,
+      result: gameState.winner || 'draw',
+      resultReason: gameOverInfo?.reason || 'unknown',
+      timeControl: BOT_GAME_TIME_CONTROL,
+      moves: gameState.moveHistory,
+      finalBoard: gameState.board,
+      moveCount: gameState.moveHistory.length,
+    };
+
+    // Save to database first, then navigate to analysis with real game ID
+    saveBotGameMutation.mutate(gameResult, {
+      onSuccess: () => {
+        navigate(`/analysis/${currentGameId}`);
+      },
+      onError: () => {
+        // Fallback: navigate to inline analysis if save fails
+        navigate(buildInlineAnalysisRoute({
+          source: 'bot',
+          moves: gameState.moveHistory,
+          result: gameState.winner || 'draw',
+          reason: gameOverInfo?.reason || 'unknown',
+        }));
+      },
+    });
+  }, [currentGameId, gameState, playerColor, playerDisplayName, botLevel, selectedBotId, gameOverInfo, navigate, saveBotGameMutation]);
+
   useEffect(() => {
     gameStateRef.current = gameState;
   }, [gameState]);
@@ -1243,14 +1281,7 @@ export default function BotGame() {
                 onRematch={handleStartGame}
                 onNewGame={handleReset}
                 onAnalyze={gameState.moveHistory.length > 0
-                  ? () => {
-                      navigate(buildInlineAnalysisRoute({
-                        source: 'bot',
-                        moves: gameState.moveHistory,
-                        result: gameState.winner || 'draw',
-                        reason: gameOverInfo.reason,
-                      }));
-                    }
+                  ? handleAnalyzeGame
                   : undefined
                 }
               />
@@ -1319,14 +1350,7 @@ export default function BotGame() {
           onRematch={handleStartGame}
           onNewGame={handleReset}
           onAnalyze={gameState.moveHistory.length > 0
-            ? () => {
-                navigate(buildInlineAnalysisRoute({
-                  source: 'bot',
-                  moves: gameState.moveHistory,
-                  result: gameState.winner || 'draw',
-                  reason: gameOverInfo.reason,
-                }));
-              }
+            ? handleAnalyzeGame
             : undefined
           }
           onClose={() => setShowGameOverModal(false)}

--- a/client/src/lib/i18n.full.tsx
+++ b/client/src/lib/i18n.full.tsx
@@ -751,6 +751,7 @@ export const EN_TRANSLATIONS: Record<string, string> = {
   'analysis.loading': 'Loading game...',
   'analysis.parse_failed': 'Failed to parse game data',
   'analysis.game_not_found': 'Game not found',
+  'analysis.session_expired': 'Game data no longer available. This can happen if you refreshed the page or opened the link in a new tab. Please play the game again to view the analysis.',
   'analysis.no_moves': 'Game has no moves to analyze',
   'analysis.failed': 'Analysis failed',
   'analysis.analyzing': 'Reviewing game...',

--- a/client/src/lib/i18n.th.ts
+++ b/client/src/lib/i18n.th.ts
@@ -712,6 +712,7 @@ export const TH_TRANSLATIONS: Record<string, string> = {
   'analysis.loading': 'กำลังโหลดเกม...',
   'analysis.parse_failed': 'อ่านข้อมูลเกมไม่สำเร็จ',
   'analysis.game_not_found': 'ไม่พบเกม',
+  'analysis.session_expired': 'ข้อมูลเกมไม่พร้อมใช้งานแล้ว อาจเกิดจากการรีเฟรชหน้าเว็บหรือเปิดลิงก์ในแท็บใหม่ กรุณาเล่นเกมใหม่อีกครั้งเพื่อดูการวิเคราะห์',
   'analysis.no_moves': 'เกมนี้ไม่มีตาเดินให้วิเคราะห์',
   'analysis.failed': 'วิเคราะห์ไม่สำเร็จ',
   'analysis.analyzing': 'กำลังตรวจเกม...',

--- a/client/src/queries/analysis.ts
+++ b/client/src/queries/analysis.ts
@@ -31,13 +31,17 @@ async function fetchGame(gameId: string): Promise<GameApiResponse> {
 
 // Query options factory
 export function gameQueryOptions(gameId: string | undefined) {
+  // Inline analysis sources that don't exist in the database
+  const inlineSources = ['bot', 'local', 'editor'];
+  const isRealGameId = Boolean(gameId && !inlineSources.includes(gameId));
+
   return queryOptions({
     queryKey: ['game', gameId],
     queryFn: () => {
       if (!gameId) throw new Error('Game ID is required');
       return fetchGame(gameId);
     },
-    enabled: Boolean(gameId),
+    enabled: isRealGameId,
     staleTime: 1000 * 60 * 5, // Game data stays fresh for 5 minutes
     gcTime: 1000 * 60 * 10, // Keep in cache for 10 minutes
   });


### PR DESCRIPTION
Previously, bot game analysis used sessionStorage which was lost on page refresh, causing 'Game not found' errors. Now bot games are saved to the database before navigating to analysis, making analysis links permanent and shareable.

Changes:
- BotGame.tsx: Save game to DB via /api/games/bot before analysis navigation
- AnalysisPage.tsx: Show helpful error when inline session data is missing
- queries/analysis.ts: Disable API queries for inline sources (bot/local/editor)
- i18n: Add 'analysis.session_expired' translations (EN/TH)

Fixes: Game not found error after refreshing bot game analysis page

## What does this PR do?

Brief description of the changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] Code compiles without errors (`npx tsc --noEmit`)
- [ ] Client builds successfully (`npm run build --workspace=client`)
- [ ] Tested locally
- [ ] No console errors in browser
