### PR TITLE
fix: persist local games to database for reliable analysis access

### DIFF
--- a/client/src/components/LocalGame.tsx
+++ b/client/src/components/LocalGame.tsx
@@ -13,6 +13,7 @@ import { buildInlineAnalysisRoute } from '../lib/analysis';
 import { getCapturedSummary } from '../lib/capturedSummary';
 import { usePostGameReview } from '../hooks/usePostGameReview';
 import { useReviewEngineAnalysis } from '../hooks/useReviewEngineAnalysis';
+import { useSaveLocalGameMutation } from '../queries/localGames';
 import AppearanceSettingsButton from './AppearanceSettingsButton';
 import { BoardErrorBoundary } from './BoardErrorBoundary';
 import Board from './Board';
@@ -27,6 +28,16 @@ import PostGameReviewPanel from './PostGameReviewPanel';
 const DEFAULT_PLAY_TIME_MS = 10 * 60 * 1000;
 const LOCAL_CLOCK_TICK_MS = 500;
 
+function createLocalGameId() {
+  return globalThis.crypto?.randomUUID?.()
+    ?? `local_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+const LOCAL_GAME_TIME_CONTROL = {
+  initial: DEFAULT_PLAY_TIME_MS / 1000,
+  increment: 0,
+};
+
 export default function LocalGame() {
   const navigate = useNavigate();
   const { t } = useTranslation();
@@ -39,6 +50,7 @@ export default function LocalGame() {
   const [showGameOverModal, setShowGameOverModal] = useState(false);
   const [arrows, setArrows] = useState<Arrow[]>([]);
   const [viewMoveIndex, setViewMoveIndex] = useState<number | null>(null);
+  const [currentGameId, setCurrentGameId] = useState<string | null>(null);
   const moveCountRef = useRef(gameState.moveHistory.length);
   const review = usePostGameReview({
     enabled: gameState.gameOver,
@@ -55,6 +67,51 @@ export default function LocalGame() {
         }
       : null,
   });
+
+  const saveLocalGameMutation = useSaveLocalGameMutation();
+
+  // Helper to save local game and navigate to analysis
+  const handleAnalyzeGame = useCallback(() => {
+    if (!currentGameId || gameState.moveHistory.length === 0) {
+      navigate('/analysis');
+      return;
+    }
+
+    const gameResult: import('../queries/localGames').LocalGameResult = {
+      id: currentGameId,
+      whiteName: 'White',
+      blackName: 'Black',
+      result: gameState.winner || 'draw',
+      resultReason: gameOverInfo?.reason || 'unknown',
+      timeControl: LOCAL_GAME_TIME_CONTROL,
+      moves: gameState.moveHistory,
+      finalBoard: gameState.board,
+      moveCount: gameState.moveHistory.length,
+    };
+
+    // Save to database first, then navigate to analysis with real game ID
+    saveLocalGameMutation.mutate(gameResult, {
+      onSuccess: () => {
+        navigate(`/analysis/${currentGameId}`);
+      },
+      onError: () => {
+        // Fallback: navigate to inline analysis if save fails
+        navigate(buildInlineAnalysisRoute({
+          source: 'local',
+          moves: gameState.moveHistory,
+          result: gameState.winner || 'draw',
+          reason: gameOverInfo?.reason || 'unknown',
+        }));
+      },
+    });
+  }, [currentGameId, gameState, gameOverInfo, navigate, saveLocalGameMutation]);
+
+  // Initialize game ID when component mounts
+  useEffect(() => {
+    if (!currentGameId) {
+      setCurrentGameId(createLocalGameId());
+    }
+  }, []);
 
   useEffect(() => {
     if (gameState.moveHistory.length === 0) return;
@@ -243,6 +300,7 @@ export default function LocalGame() {
     setShowGameOverModal(false);
     setArrows([]);
     setViewMoveIndex(null);
+    setCurrentGameId(null);
   };
 
   const getLastMove = (): Move | null => {
@@ -475,14 +533,7 @@ export default function LocalGame() {
                 onRematch={handleReset}
                 onNewGame={() => navigate('/')}
                 onAnalyze={gameState.moveHistory.length > 0
-                  ? () => {
-                      navigate(buildInlineAnalysisRoute({
-                        source: 'local',
-                        moves: gameState.moveHistory,
-                        result: gameState.winner || 'draw',
-                        reason: gameOverInfo.reason,
-                      }));
-                    }
+                  ? handleAnalyzeGame
                   : undefined
                 }
               />
@@ -544,14 +595,7 @@ export default function LocalGame() {
           onRematch={handleReset}
           onNewGame={() => navigate('/')}
           onAnalyze={gameState.moveHistory.length > 0
-            ? () => {
-                navigate(buildInlineAnalysisRoute({
-                  source: 'local',
-                  moves: gameState.moveHistory,
-                  result: gameState.winner || 'draw',
-                  reason: gameOverInfo.reason,
-                }));
-              }
+            ? handleAnalyzeGame
             : undefined
           }
           onClose={() => setShowGameOverModal(false)}

--- a/client/src/queries/localGames.ts
+++ b/client/src/queries/localGames.ts
@@ -1,0 +1,36 @@
+import { useMutation } from '@tanstack/react-query';
+import type { Move, Board } from '@shared/types';
+
+export interface LocalGameResult {
+  id: string;
+  whiteName?: string;
+  blackName?: string;
+  result: 'white' | 'black' | 'draw';
+  resultReason: string;
+  timeControl: { initial: number; increment: number };
+  moves: Move[];
+  finalBoard: Board;
+  moveCount: number;
+}
+
+// API function for saving local game result
+async function saveLocalGame(result: LocalGameResult): Promise<void> {
+  const response = await fetch('/api/games/local', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(result),
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to save local game');
+  }
+}
+
+// Mutation hook for saving local game
+export function useSaveLocalGameMutation() {
+  return useMutation({
+    mutationFn: saveLocalGame,
+    // No query invalidation needed - this is a "fire and forget" operation
+    // The game is already over, we just want to persist it
+  });
+}

--- a/client/src/test/LocalGame.test.tsx
+++ b/client/src/test/LocalGame.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import LocalGame from '../components/LocalGame';
 
 const {
@@ -97,12 +98,30 @@ vi.mock('../components/InGameShell', () => ({
   },
 }));
 
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: Infinity,
+      },
+    },
+  });
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <MemoryRouter>
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      </MemoryRouter>
+    );
+  };
+}
+
 function renderLocalGame() {
-  return render(
-    <MemoryRouter>
-      <LocalGame />
-    </MemoryRouter>
-  );
+  const Wrapper = createWrapper();
+  return render(<LocalGame />, { wrapper: Wrapper });
 }
 
 describe('LocalGame', () => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -64,6 +64,7 @@ import {
   ReportFairPlaySchema,
   FairPlayCaseActionSchema,
   SaveBotGameSchema,
+  SaveLocalGameSchema,
   AnalyzeGameSchema,
   AnalyzePositionSchema,
   BotMoveSchema,
@@ -561,6 +562,56 @@ app.post('/api/games/bot', async (req, res) => {
     id,
     opponentName: botName,
     gameType: 'bot',
+  });
+});
+
+app.post('/api/games/local', async (req, res) => {
+  const parseResult = SaveLocalGameSchema.safeParse(req.body);
+  if (!parseResult.success) {
+    const flattened = parseResult.error.flatten();
+    const fieldErrors = Object.values(flattened.fieldErrors);
+    const firstFieldError = fieldErrors.find(err => err && err.length > 0)?.[0];
+    const formError = flattened.formErrors[0];
+    const errorMessage = firstFieldError || formError || 'Valid local game payload is required.';
+    res.status(400).json({ error: errorMessage });
+    return;
+  }
+
+  const {
+    id,
+    result,
+    resultReason,
+    whiteName,
+    blackName,
+    moves,
+    finalBoard,
+    moveCount,
+    timeControl,
+  } = parseResult.data;
+
+  await saveCompletedGame({
+    id,
+    result,
+    resultReason,
+    whiteName: whiteName || 'White',
+    blackName: blackName || 'Black',
+    whiteUserId: null,
+    blackUserId: null,
+    rated: false,
+    gameMode: 'private',
+    gameType: 'human',
+    opponentType: null,
+    opponentName: null,
+    timeControl,
+    moves,
+    finalBoard,
+    moveCount: moveCount ?? moves.length,
+  });
+
+  res.json({
+    ok: true,
+    id,
+    gameType: 'local',
   });
 });
 

--- a/shared/validation/api.ts
+++ b/shared/validation/api.ts
@@ -126,6 +126,31 @@ export const SaveBotGameSchema = z.object({
 });
 export type SaveBotGamePayload = z.infer<typeof SaveBotGameSchema>;
 
+export const SaveLocalGameSchema = z.object({
+  id: z.string()
+    .min(4, 'Game ID too short')
+    .max(32, 'Game ID too long')
+    .regex(/^[A-Za-z0-9-]+$/, 'Invalid game ID format'),
+  result: z.enum(['white', 'black', 'draw']),
+  resultReason: z.string().min(1, 'Result reason is required'),
+  whiteName: z.string()
+    .max(50, 'White player name too long')
+    .optional()
+    .transform((name) => name?.trim()),
+  blackName: z.string()
+    .max(50, 'Black player name too long')
+    .optional()
+    .transform((name) => name?.trim()),
+  moves: z.array(z.any()).min(1, 'Moves are required'),
+  finalBoard: z.array(z.any()).min(1, 'Final board is required'),
+  moveCount: z.number().int().min(0).optional(),
+  timeControl: z.object({
+    initial: z.number().int().min(10).max(7200),
+    increment: z.number().int().min(0).max(60),
+  }),
+});
+export type SaveLocalGamePayload = z.infer<typeof SaveLocalGameSchema>;
+
 // ============================================
 // Analysis Endpoints
 // ============================================


### PR DESCRIPTION
Apply the same fix pattern from bot games to local games. Local games (pass-and-play) now save to the database before navigating to analysis, making analysis links permanent and refreshable.

Changes:
- LocalGame.tsx: Save game to DB via /api/games/local before analysis navigation
- server/index.ts: Add POST /api/games/local endpoint
- validation/api.ts: Add SaveLocalGameSchema
- queries/localGames.ts: New mutation hook for saving local games

Fixes: Game not found error after refreshing local game analysis page

## What does this PR do?

Brief description of the changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] Code compiles without errors (`npx tsc --noEmit`)
- [ ] Client builds successfully (`npm run build --workspace=client`)
- [ ] Tested locally
- [ ] No console errors in browser
