### PR TITLE
ci(anti-slop): add comprehensive quality checks to PR workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,79 @@ jobs:
         uses: peakoss/anti-slop@v0.2.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          
+          # General Settings
+          max-failures: 4
+
+          # PR Branch Checks
+          allowed-target-branches: "main"
+          blocked-source-branches: |
+            main
+            master
+
+          # PR Quality Checks
+          max-negative-reactions: 0
+          require-maintainer-can-modify: true
+
+          # PR Title Checks
+          require-conventional-title: true
+
+          # PR Description Checks
+          require-description: true
+          max-description-length: 3000
+          max-emoji-count: 5
+          max-code-references: 10
+          require-linked-issue: false
+
+          # PR Template Checks
+          require-pr-template: false
+
+          # Commit Message Checks
+          max-commit-message-length: 500
+          require-conventional-commits: true
+          require-commit-author-match: true
+
+          # File Checks
+          blocked-paths: |
+            README.md
+            SECURITY.md
+            LICENSE
+            CODE_OF_CONDUCT.md
+          require-final-newline: true
+          max-added-comments: 15
+
+          # User Checks
+          detect-spam-usernames: true
+          min-account-age: 7
+          max-daily-forks: 10
+          min-profile-completeness: 3
+
+          # Merge Checks
+          min-repo-merged-prs: 0
+          min-repo-merge-ratio: 0
+          min-global-merge-ratio: 20
+
+          # Exemptions
+          exempt-draft-prs: true
+          exempt-bots: |
+            actions-user
+            dependabot[bot]
+            renovate[bot]
+            github-actions[bot]
+          exempt-author-association: "OWNER,MEMBER,COLLABORATOR"
+
+          # PR Failure Actions
+          close-pr: false
+          failure-pr-message: |
+            👋 Hi! This PR doesn't meet our quality standards.
+            
+            Please check:
+            - PR title follows conventional commits (e.g., "feat:", "fix:", "test:")
+            - PR has a meaningful description
+            - Commit messages follow conventional format
+            - No blocked files are being modified
+            
+            See our contributing guidelines for more details.
 
   test:
     name: Unit And Integration Tests


### PR DESCRIPTION
Add meaningful anti-slop configuration to actually check PR quality:

- Require conventional PR titles (feat:, fix:, test:, etc.)
- Require conventional commit messages
- Require PR descriptions with reasonable limits
- Block direct pushes to main/master from PR branches
- Block modifications to sensitive files (README, LICENSE, etc.)
- Detect spam usernames and enforce minimum account age
- Exempt draft PRs, bots, and maintainers appropriately
- Set failure threshold to 4 max failures before action
- Add helpful failure message with guidance

This ensures the anti-slop check actually validates PR quality instead of completing in 4 seconds with no checks enabled.

## What does this PR do?

Brief description of the changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] Code compiles without errors (`npx tsc --noEmit`)
- [ ] Client builds successfully (`npm run build --workspace=client`)
- [ ] Tested locally
- [ ] No console errors in browser
