### PR TITLE
fix(analysis): prevent 429 rate limit errors when auto-analyzing games

### DIFF
--- a/client/src/hooks/useReviewEngineAnalysis.ts
+++ b/client/src/hooks/useReviewEngineAnalysis.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 import type { AnalysisPositionSnapshot, PositionAnalysisResult } from '@shared/engineAdapter';
 import { requestPositionAnalysis } from '../lib/analysis';
 
@@ -14,57 +14,145 @@ interface UseReviewEngineAnalysisResult {
 }
 
 const REVIEW_ENGINE_MOVETIME_MS = 700;
-const REVIEW_ENGINE_DEBOUNCE_MS = 120;
+const REVIEW_ENGINE_DEBOUNCE_MS = 800; // Increased from 120ms to 800ms to avoid rate limits
+const MAX_RETRIES = 3;
+const RETRY_DELAY_BASE_MS = 2000; // Start with 2 second delay for retries
+
+// Simple request deduplication cache
+const requestCache = new Map<string, Promise<PositionAnalysisResult>>();
+
+function getCacheKey(snapshot: AnalysisPositionSnapshot, options: { movetimeMs: number; multipv: number }): string {
+  const position = JSON.stringify(snapshot.board) + snapshot.turn + JSON.stringify(snapshot.counting);
+  return `${position}:${options.movetimeMs}:${options.multipv}`;
+}
 
 export function useReviewEngineAnalysis(
   options: UseReviewEngineAnalysisOptions,
 ): UseReviewEngineAnalysisResult {
   const { enabled, snapshot } = options;
   const requestIdRef = useRef(0);
+  const retryCountRef = useRef(0);
+  const retryTimeoutRef = useRef<number | null>(null);
   const [analysis, setAnalysis] = useState<PositionAnalysisResult | null>(null);
   const [analyzing, setAnalyzing] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Clear retry timeout on unmount
   useEffect(() => {
+    return () => {
+      if (retryTimeoutRef.current) {
+        window.clearTimeout(retryTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const performAnalysis = useCallback(async (
+    requestId: number,
+    controller: AbortController,
+    attemptNumber: number,
+  ): Promise<void> => {
+    if (!snapshot) return;
+
+    const cacheKey = getCacheKey(snapshot, { movetimeMs: REVIEW_ENGINE_MOVETIME_MS, multipv: 3 });
+
+    // Check if there's already an in-flight request for this position
+    let analysisPromise = requestCache.get(cacheKey);
+
+    if (!analysisPromise) {
+      // Create new request
+      analysisPromise = requestPositionAnalysis(snapshot, {
+        movetimeMs: REVIEW_ENGINE_MOVETIME_MS,
+        multipv: 3,
+        signal: controller.signal,
+      });
+
+      requestCache.set(cacheKey, analysisPromise);
+
+      // Clean up cache after request completes (success or failure)
+      analysisPromise
+        .then(() => {
+          setTimeout(() => requestCache.delete(cacheKey), 100);
+        })
+        .catch(() => {
+          setTimeout(() => requestCache.delete(cacheKey), 100);
+        });
+    }
+
+    try {
+      const result = await analysisPromise;
+
+      // Only update state if this is still the current request
+      if (requestIdRef.current !== requestId) return;
+
+      setAnalysis(result);
+      setError(null);
+      retryCountRef.current = 0;
+    } catch (requestError) {
+      // Only update state if this is still the current request and not aborted
+      if (controller.signal.aborted || requestIdRef.current !== requestId) return;
+
+      // Check if it's a rate limit error (429)
+      const errorMessage = requestError instanceof Error ? requestError.message : 'Engine analysis failed';
+      const isRateLimitError = errorMessage.includes('429') || errorMessage.includes('Too Many Requests');
+
+      if (isRateLimitError && attemptNumber < MAX_RETRIES) {
+        // Exponential backoff for rate limit errors
+        const delay = RETRY_DELAY_BASE_MS * Math.pow(2, attemptNumber);
+        retryCountRef.current = attemptNumber + 1;
+
+        retryTimeoutRef.current = window.setTimeout(() => {
+          if (requestIdRef.current === requestId) {
+            performAnalysis(requestId, controller, attemptNumber + 1);
+          }
+        }, delay);
+
+        return;
+      }
+
+      setAnalysis(null);
+      setError(isRateLimitError
+        ? 'Analysis rate limit reached. Please wait a moment and try again.'
+        : errorMessage,
+      );
+    } finally {
+      if (requestIdRef.current === requestId) {
+        setAnalyzing(false);
+      }
+    }
+  }, [snapshot]);
+
+  useEffect(() => {
+    // Clear any pending retry timeout
+    if (retryTimeoutRef.current) {
+      window.clearTimeout(retryTimeoutRef.current);
+      retryTimeoutRef.current = null;
+    }
+
     if (!enabled || !snapshot) {
       setAnalysis(null);
       setAnalyzing(false);
       setError(null);
+      retryCountRef.current = 0;
       return;
     }
 
     const requestId = requestIdRef.current + 1;
     requestIdRef.current = requestId;
     const controller = new AbortController();
-    const timer = window.setTimeout(async () => {
+
+    const timer = window.setTimeout(() => {
       setAnalyzing(true);
       setError(null);
+      retryCountRef.current = 0;
 
-      try {
-        const result = await requestPositionAnalysis(snapshot, {
-          movetimeMs: REVIEW_ENGINE_MOVETIME_MS,
-          multipv: 3,
-          signal: controller.signal,
-        });
-
-        if (requestIdRef.current !== requestId) return;
-        setAnalysis(result);
-      } catch (requestError) {
-        if (controller.signal.aborted || requestIdRef.current !== requestId) return;
-        setAnalysis(null);
-        setError(requestError instanceof Error ? requestError.message : 'Engine analysis failed');
-      } finally {
-        if (requestIdRef.current === requestId) {
-          setAnalyzing(false);
-        }
-      }
+      performAnalysis(requestId, controller, 0);
     }, REVIEW_ENGINE_DEBOUNCE_MS);
 
     return () => {
       window.clearTimeout(timer);
       controller.abort();
     };
-  }, [enabled, snapshot]);
+  }, [enabled, snapshot, performAnalysis]);
 
   return {
     analysis,

--- a/client/src/lib/analysis.ts
+++ b/client/src/lib/analysis.ts
@@ -93,7 +93,17 @@ export async function requestPositionAnalysis(
   });
 
   if (!response.ok) {
-    throw new Error('Position analysis request failed');
+    // Provide specific error messages for common HTTP errors
+    if (response.status === 429) {
+      throw new Error('429 Too Many Requests: Analysis rate limit exceeded. Please wait a moment.');
+    }
+    if (response.status === 503) {
+      throw new Error('503 Service Unavailable: Analysis engine is temporarily unavailable.');
+    }
+    if (response.status >= 500) {
+      throw new Error(`Server error (${response.status}): Position analysis request failed`);
+    }
+    throw new Error(`Position analysis request failed (${response.status})`);
   }
 
   return await response.json() as PositionAnalysisResult;


### PR DESCRIPTION
- Increase debounce from 120ms to 800ms to reduce request frequency
- Add request deduplication cache to prevent duplicate in-flight requests
- Implement exponential backoff retry logic (2s, 4s, 8s) for 429 errors
- Add specific HTTP error handling with user-friendly messages

Fixes issue where playing against yourself in same browser caused multiple tabs to exceed the 20 req/min rate limit on /api/analysis/position

## What does this PR do?

Brief description of the changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] Code compiles without errors (`npx tsc --noEmit`)
- [ ] Client builds successfully (`npm run build --workspace=client`)
- [ ] Tested locally
- [ ] No console errors in browser
