### PR TITLE
fix: add URL canonicalization redirects for SEO

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -108,6 +108,41 @@ app.use(express.json());
 // Trust proxy for rate limiting behind reverse proxy (Fly.io, nginx, etc.)
 app.set('trust proxy', 1);
 
+// URL Canonicalization Redirects (SEO - fix Google Search Console issues)
+// Redirects: www → non-www, HTTP → HTTPS, trailing slash normalization
+app.use((req, res, next) => {
+  const host = req.get('host') || '';
+  const protocol = req.protocol;
+  const url = req.originalUrl;
+
+  let redirectUrl: string | null = null;
+  let statusCode = 301; // Permanent redirect for SEO
+
+  // 1. Redirect www to non-www
+  if (host.startsWith('www.')) {
+    const nonWwwHost = host.slice(4);
+    redirectUrl = `https://${nonWwwHost}${url}`;
+  }
+  // 2. Redirect HTTP to HTTPS (only in production, skip localhost)
+  else if (protocol === 'http' && !host.includes('localhost') && !host.includes('127.0.0.1')) {
+    redirectUrl = `https://${host}${url}`;
+  }
+
+  // 3. Trailing slash normalization (except for files with extensions)
+  // Remove trailing slash from URLs like /about/ → /about
+  // But keep it for root / and file paths like /assets/image.png
+  if (!redirectUrl && url.length > 1 && url.endsWith('/') && !url.match(/\/[^/]+\.[^/]+$/)) {
+    redirectUrl = `https://${host}${url.slice(0, -1)}`;
+  }
+
+  if (redirectUrl) {
+    res.redirect(statusCode, redirectUrl);
+    return;
+  }
+
+  next();
+});
+
 // Rate limiting for API endpoints
 const apiLimiter = rateLimit({
   windowMs: 60 * 1000, // 1 minute


### PR DESCRIPTION
Add middleware to handle SEO redirects:
- www → non-www (e.g., www.thaichess.dev → thaichess.dev)
- HTTP → HTTPS (production only)
- Trailing slash normalization (/about/ → /about)

Fixes Google Search Console 'Page with redirect' validation errors. All redirects use 301 permanent status for SEO benefits.

## What does this PR do?

Brief description of the changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] Code compiles without errors (`npx tsc --noEmit`)
- [ ] Client builds successfully (`npm run build --workspace=client`)
- [ ] Tested locally
- [ ] No console errors in browser
