### PR TITLE
feat: enhance Thai SEO to compete with top competitors

### DIFF
--- a/server/src/seoHtml.ts
+++ b/server/src/seoHtml.ts
@@ -77,6 +77,10 @@ export function renderSeoHtml(template: string, pathname: string, baseUrl: strin
   html = upsertHeadTag(html, /<meta\s+name="twitter:title"\s+content="[^"]*"\s*\/?>/i, `<meta name="twitter:title" content="${escapeHtml(seo.title)}" />`);
   html = upsertHeadTag(html, /<meta\s+name="twitter:description"\s+content="[^"]*"\s*\/?>/i, `<meta name="twitter:description" content="${escapeHtml(seo.description)}" />`);
 
+  // Add hreflang tags for bilingual SEO (Thai/English)
+  const thaiUrl = new URL(seo.path, `${baseUrl}/`).toString();
+  html = upsertHeadTag(html, /<link\s+rel="alternate"\s+hreflang="[^"]*"\s+href="[^"]*"\s*\/?>/i, `<link rel="alternate" hreflang="en" href="${escapeHtml(thaiUrl)}" />\n  <link rel="alternate" hreflang="th" href="${escapeHtml(thaiUrl)}" />\n  <link rel="alternate" hreflang="x-default" href="${escapeHtml(thaiUrl)}" />`);
+
   html = html.replace(/\s*<script[^>]*data-seo-server="true"[^>]*>.*?<\/script>/gs, '');
   if (structuredData) {
     html = html.replace('</head>', `  <script type="application/ld+json" data-seo-server="true">${structuredData}</script>\n  </head>`);

--- a/shared/seo.ts
+++ b/shared/seo.ts
@@ -35,9 +35,24 @@ const defaultKeywords = [
   'Makruk',
   'Thai chess',
   'หมากรุกไทย',
+  'เล่นหมากรุกไทย',
+  'เล่นหมากรุกไทยออนไลน์',
+  'กติกาหมากรุกไทย',
+  'วิธีเล่นหมากรุกไทย',
+  'สอนหมากรุกไทย',
+  'หมากรุกไทยออนไลน์',
   'play ThaiChess online',
   'Makruk puzzles',
   'Thai chess strategy',
+  'Makruk rules',
+  'Thai chess counting rule',
+  'อุกจตุรงค์',
+  'Cambodian chess',
+  'หมากรุกไทยกับหมากรุกสากล',
+  'Thai chess vs chess',
+  'Makruk endgame',
+  'หมากรุกไทยขั้นเทพ',
+  'โปรแกรมหมากรุกไทย',
 ];
 
 function getPublicPuzzleSeoTitle(title: string): string {
@@ -139,10 +154,10 @@ export function getPublicSeoRoute(pathname: string, baseUrl: string): SeoRouteDa
 
   if (cleanPath === '/') {
     return {
-      title: 'Play Makruk (หมากรุกไทย) Online Free | ThaiChess',
-      description: 'Play ThaiChess online for free. Challenge friends, practice against a bot, solve Makruk puzzles, and learn the traditional Thai chess game, also known as หมากรุกไทย.',
+      title: 'เล่นหมากรุกไทยออนไลน์ฟรี | Play Makruk Online Free | ThaiChess',
+      description: 'เล่นหมากรุกไทยออนไลน์ฟรี ฝึกกับบอท แก้โจทย์หมากรุกไทย และเรียนรู้กติกา วิธีเล่นหมากรุกไทยสำหรับมือใหม่ Play ThaiChess online for free.',
       path: '/',
-      keywords: [...defaultKeywords, 'play with friends', 'Thai chess bot', 'เล่นหมากรุกไทยออนไลน์'],
+      keywords: [...defaultKeywords, 'เล่นหมากรุกไทยฟรี', 'หมากรุกไทยออนไลน์', 'สอนหมากรุกไทย', 'Makruk online free', 'Thai chess online free'],
       type: 'website',
       structuredData: [
         buildWebsiteSchema(baseUrl),
@@ -151,20 +166,22 @@ export function getPublicSeoRoute(pathname: string, baseUrl: string): SeoRouteDa
       ],
       snapshot: {
         kicker: { text: 'ThaiChess • Makruk • หมากรุกไทย' },
-        heading: { text: 'Play Makruk Online' },
+        heading: { text: 'เล่นหมากรุกไทยออนไลน์', lang: 'th' },
         paragraphs: [
           { text: 'Makruk, or Thai chess, is the traditional chess game of Thailand. ThaiChess lets you play online, solve puzzles, and study the game in your browser.' },
-          { text: 'เว็บไซต์นี้สอนและให้เล่นหมากรุกไทยออนไลน์ ทั้งโหมดเจอเพื่อน เล่นกับบอท และฝึกจากโจทย์หมากรุกไทย', lang: 'th' },
+          { text: 'หมากรุกไทยหรือ Makruk เป็นหมากรุกดั้งเดิมของไทย เว็บไซต์นี้ให้เล่นหมากรุกไทยออนไลน์ฟรี ฝึกกับบอท แก้โจทย์ และเรียนรู้กติกา', lang: 'th' },
         ],
         bullets: [
+          { text: 'เล่นหมากรุกไทยออนไลน์กับเพื่อนหรือผู้เล่นทั่วโลก', lang: 'th' },
+          { text: 'ฝึกหมากรุกไทยกับบอทและเรียนรู้จากบทเรียน', lang: 'th' },
+          { text: 'แก้โจทย์หมากรุกไทยเพื่อพัฒนาทักษะการคำนวณ', lang: 'th' },
           { text: 'Play with friends, quick matchmaking, or a practice bot.' },
           { text: 'Learn rules, openings, tactics, and the counting rule.' },
-          { text: 'ฝึกหมากรุกไทยจากบทเรียนและโจทย์ที่เล่นได้ทันที', lang: 'th' },
         ],
         links: [
-          { href: '/what-is-makruk', label: 'What Is Makruk?' },
+          { href: '/what-is-makruk', label: 'หมากรุกไทยคืออะไร', lang: 'th' },
           { href: '/how-to-play-makruk', label: 'วิธีเล่นหมากรุกไทย', lang: 'th' },
-          { href: '/play-makruk-online', label: 'Play Makruk Online' },
+          { href: '/play-makruk-online', label: 'เริ่มเล่นหมากรุกไทย', lang: 'th' },
         ],
       },
     };
@@ -289,21 +306,29 @@ export function getPublicSeoRoute(pathname: string, baseUrl: string): SeoRouteDa
 
   if (cleanPath === '/how-to-play-makruk') {
     return {
-      title: 'How to Play Makruk (หมากรุกไทย) | Thai Chess Rules for Beginners',
-      description: 'Learn how to play Makruk with board setup, piece movement, promotion, and the counting rule in a beginner-friendly Thai chess guide for หมากรุกไทย.',
+      title: 'วิธีเล่นหมากรุกไทย | กติกาหมากรุกไทยสำหรับมือใหม่ | How to Play Makruk',
+      description: 'สอนวิธีเล่นหมากรุกไทย กติกาหมากรุกไทย การเดินหมากแต่ละตัว การหงาย และกฎการนับสำหรับผู้เริ่มเล่น Learn how to play Makruk with board setup, piece movement, promotion, and the counting rule.',
       path: '/how-to-play-makruk',
-      keywords: [...defaultKeywords, 'Makruk rules', 'how to play Makruk', 'Thai chess rules', 'วิธีเล่นหมากรุกไทย'],
+      keywords: [...defaultKeywords, 'กติกาหมากรุกไทย', 'วิธีเล่นหมากรุกไทย', 'สอนหมากรุกไทย', 'Makruk rules', 'Thai chess rules', 'how to play Makruk', 'หมากรุกไทยขั้นเทพ'],
       type: 'article',
       structuredData: [
         {
           '@context': 'https://schema.org',
           '@type': 'HowTo',
-          name: 'How to Play Makruk (หมากรุกไทย)',
+          name: 'วิธีเล่นหมากรุกไทย | How to Play Makruk',
           url: `${baseUrl}/how-to-play-makruk`,
-          description: 'A beginner-friendly guide to the rules of Thai chess.',
+          description: 'คู่มือสอนหมากรุกไทยสำหรับมือใหม่ A beginner-friendly guide to the rules of Thai chess.',
           inLanguage: ['en', 'th'],
         },
         buildFaqSchema([
+          {
+            question: 'หมากรุกไทยมีการกรอกหรือกินหมากผ่านทางไหม?',
+            answer: 'ไม่มี หมากรุกไทยไม่มีการกรอก ไม่มีการกินหมากผ่านทาง และเบี้ยเดินหนึ่งช่องตลอด',
+          },
+          {
+            question: 'กฎการนับคืออะไร?',
+            answer: 'กฎการนับเป็นวิธีจำกัดจำนวนเทิร์นเมื่อเหลือตัวหมากน้อย เพื่อป้องกันการยื้อเกม ถ้าฝ่ายที่เหนือกว่าไม่สามารถรุกจนได้ภายในเทิร์นที่กำหนด จะเสมอ',
+          },
           {
             question: 'Does Makruk have castling or en passant?',
             answer: 'No. Makruk has no castling, no en passant, and no two-square pawn jump.',
@@ -315,15 +340,18 @@ export function getPublicSeoRoute(pathname: string, baseUrl: string): SeoRouteDa
         ]),
       ],
       snapshot: {
-        heading: { text: 'How to Play Makruk' },
+        heading: { text: 'วิธีเล่นหมากรุกไทย', lang: 'th' },
         paragraphs: [
           { text: 'Learn the board setup, piece movement, promotion, and the counting rule in a practical guide for new Makruk players.' },
-          { text: 'เรียนรู้การจัดกระดาน การเดินหมาก การหงาย และกฎการนับสำหรับผู้เริ่มเล่นหมากรุกไทย', lang: 'th' },
+          { text: 'เรียนรู้การจัดกระดาน การเดินหมากแต่ละตัว การหงายเบี้ย และกฎการนับสำหรับผู้เริ่มเล่นหมากรุกไทย', lang: 'th' },
         ],
         bullets: [
+          { text: 'การจัดกระดานและตำแหน่งเริ่มต้น', lang: 'th' },
+          { text: 'การเดินหมากแต่ละตัวในหมากรุกไทย', lang: 'th' },
+          { text: 'กฎการหงายและการรุกจน', lang: 'th' },
+          { text: 'กฎการนับที่มือใหม่ต้องรู้', lang: 'th' },
           { text: 'Board setup and starting position.' },
           { text: 'How each piece moves in Thai chess.' },
-          { text: 'กฎสำคัญที่มือใหม่ต้องรู้ก่อนเริ่มเล่น', lang: 'th' },
         ],
       },
     };


### PR DESCRIPTION
Add hreflang tags for bilingual SEO (th/en/x-default) Expand Thai keywords targeting:
- เล่นหมากรุกไทย, กติกาหมากรุกไทย, สอนหมากรุกไทย
- หมากรุกไทยขั้นเทพ, โปรแกรมหมากรุกไทย
- อุกจตุรงค์, Makruk vs chess

Enhance homepage SEO with Thai-first title:
- 'เล่นหมากรุกไทยออนไลน์ฟรี | Play Makruk Online Free'

Improve how-to-play page with Thai-first title:
- 'วิธีเล่นหมากรุกไทย | กติกาหมากรุกไทยสำหรับมือใหม่'

Add Thai FAQ entries about counting rule and castling Expand Thai content in SEO snapshots for better crawling

## What does this PR do?

Brief description of the changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] Code compiles without errors (`npx tsc --noEmit`)
- [ ] Client builds successfully (`npm run build --workspace=client`)
- [ ] Tested locally
- [ ] No console errors in browser
