### PR TITLE
security: disable x-powered-by header to hide Express version

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -78,6 +78,7 @@ import {
 } from '../../shared/validation';
 
 const app = express();
+app.disable('x-powered-by');
 const httpServer = createServer(app);
 const startTime = Date.now();
 const moduleInitUptimeMs = Math.round(process.uptime() * 1000);


### PR DESCRIPTION
Adds app.disable('x-powered-by') to prevent information disclosure about the server technology stack. This improves security by making it harder for attackers to target known Express vulnerabilities.

Part of nginx security hardening implementation.

## What does this PR do?

Brief description of the changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] Code compiles without errors (`npx tsc --noEmit`)
- [ ] Client builds successfully (`npm run build --workspace=client`)
- [ ] Tested locally
- [ ] No console errors in browser
