### PR TITLE
fix: canonicalize makruk guide URLs

### DIFF
--- a/client/src/test/seo.test.ts
+++ b/client/src/test/seo.test.ts
@@ -59,6 +59,14 @@ describe('shared SEO routes', () => {
     expect(playOnline.robots).toBeUndefined();
   });
 
+  it('normalizes trailing slash guide URLs to the canonical sitemap path', () => {
+    const howTo = getPublicSeoRoute('/how-to-play-makruk/', 'https://thaichess.dev');
+
+    expect(howTo.path).toBe(routes.howToPlayMakruk);
+    expect(howTo.title).toContain('How to Play Makruk');
+    expect(howTo.robots).toBeUndefined();
+  });
+
   it('returns dedicated metadata for the lessons section and its aliases', () => {
     const overview = getPublicSeoRoute(routes.lessons, 'https://thaichess.dev');
     const alias = getPublicSeoRoute(routes.coursePath, 'https://thaichess.dev');

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -58,6 +58,7 @@ import { deserializeAnalysisPosition } from '../../shared/engineAdapter';
 import type { Move } from '../../shared/types';
 import { getBotPersonaById } from '../../shared/botPersonas';
 import { renderSeoHtml } from './seoHtml';
+import { getCanonicalRedirectUrl } from './urlCanonicalization';
 import {
   UpdateProfileSchema,
   SubmitFeedbackSchema,
@@ -113,32 +114,14 @@ app.set('trust proxy', 1);
 // URL Canonicalization Redirects (SEO - fix Google Search Console issues)
 // Redirects: www → non-www, HTTP → HTTPS, trailing slash normalization
 app.use((req, res, next) => {
-  const host = req.get('host') || '';
-  const protocol = req.protocol;
-  const url = req.originalUrl;
-
-  let redirectUrl: string | null = null;
-  let statusCode = 301; // Permanent redirect for SEO
-
-  // 1. Redirect www to non-www
-  if (host.startsWith('www.')) {
-    const nonWwwHost = host.slice(4);
-    redirectUrl = `https://${nonWwwHost}${url}`;
-  }
-  // 2. Redirect HTTP to HTTPS (only in production, skip localhost)
-  else if (protocol === 'http' && !host.includes('localhost') && !host.includes('127.0.0.1')) {
-    redirectUrl = `https://${host}${url}`;
-  }
-
-  // 3. Trailing slash normalization (except for files with extensions)
-  // Remove trailing slash from URLs like /about/ → /about
-  // But keep it for root / and file paths like /assets/image.png
-  if (!redirectUrl && url.length > 1 && url.endsWith('/') && !url.match(/\/[^/]+\.[^/]+$/)) {
-    redirectUrl = `https://${host}${url.slice(0, -1)}`;
-  }
+  const redirectUrl = getCanonicalRedirectUrl({
+    host: req.get('host') || '',
+    protocol: req.protocol,
+    originalUrl: req.originalUrl,
+  });
 
   if (redirectUrl) {
-    res.redirect(statusCode, redirectUrl);
+    res.redirect(301, redirectUrl);
     return;
   }
 

--- a/server/src/test/seoHtml.test.ts
+++ b/server/src/test/seoHtml.test.ts
@@ -32,6 +32,15 @@ describe('renderSeoHtml', () => {
     expect(html).toContain('application/ld+json');
   });
 
+  it('renders trailing-slash guide requests with canonical guide metadata', () => {
+    const html = renderSeoHtml(template, '/how-to-play-makruk/', 'https://thaichess.dev');
+
+    expect(html).toContain('<link rel="canonical" href="https://thaichess.dev/how-to-play-makruk" />');
+    expect(html).toContain('วิธีเล่นหมากรุกไทย');
+    expect(html).toContain('"@type":"HowTo"');
+    expect(html).toContain('<div id="root"><main data-seo-snapshot="true">');
+  });
+
   it('does not inject a snapshot for noindex routes', () => {
     const html = renderSeoHtml(template, '/login', 'https://thaichess.dev');
 

--- a/server/src/test/urlCanonicalization.test.ts
+++ b/server/src/test/urlCanonicalization.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { getCanonicalRedirectUrl } from '../urlCanonicalization';
+
+describe('getCanonicalRedirectUrl', () => {
+  it('redirects trailing-slash app routes to the sitemap URL', () => {
+    expect(getCanonicalRedirectUrl({
+      host: 'thaichess.dev',
+      protocol: 'https',
+      originalUrl: '/how-to-play-makruk/',
+    })).toBe('https://thaichess.dev/how-to-play-makruk');
+  });
+
+  it('preserves query strings when removing trailing slashes', () => {
+    expect(getCanonicalRedirectUrl({
+      host: 'thaichess.dev',
+      protocol: 'https',
+      originalUrl: '/how-to-play-makruk/?utm_source=gsc',
+    })).toBe('https://thaichess.dev/how-to-play-makruk?utm_source=gsc');
+  });
+
+  it('keeps root and static file URLs unchanged', () => {
+    expect(getCanonicalRedirectUrl({
+      host: 'thaichess.dev',
+      protocol: 'https',
+      originalUrl: '/',
+    })).toBeNull();
+    expect(getCanonicalRedirectUrl({
+      host: 'thaichess.dev',
+      protocol: 'https',
+      originalUrl: '/assets/piece.svg',
+    })).toBeNull();
+  });
+});

--- a/server/src/urlCanonicalization.ts
+++ b/server/src/urlCanonicalization.ts
@@ -1,0 +1,37 @@
+export function getCanonicalRedirectUrl(options: {
+  host: string;
+  protocol: string;
+  originalUrl: string;
+}): string | null {
+  const { host, protocol, originalUrl } = options;
+  const requestHost = host || 'localhost';
+  const parsedUrl = new URL(originalUrl, `https://${requestHost}`);
+  let canonicalHost = requestHost;
+  let canonicalProtocol = protocol;
+  let canonicalPathname = parsedUrl.pathname;
+  let changed = false;
+
+  if (canonicalHost.startsWith('www.')) {
+    canonicalHost = canonicalHost.slice(4);
+    canonicalProtocol = 'https';
+    changed = true;
+  } else if (canonicalProtocol === 'http' && !canonicalHost.includes('localhost') && !canonicalHost.includes('127.0.0.1')) {
+    canonicalProtocol = 'https';
+    changed = true;
+  }
+
+  if (
+    canonicalPathname.length > 1
+    && canonicalPathname.endsWith('/')
+    && !/\/[^/]+\.[^/]+$/.test(canonicalPathname)
+  ) {
+    canonicalPathname = canonicalPathname.replace(/\/+$/, '');
+    changed = true;
+  }
+
+  if (!changed) {
+    return null;
+  }
+
+  return `${canonicalProtocol}://${canonicalHost}${canonicalPathname}${parsedUrl.search}`;
+}

--- a/shared/seo.ts
+++ b/shared/seo.ts
@@ -149,8 +149,18 @@ function buildFaqSchema(entries: Array<{ question: string; answer: string }>): R
   };
 }
 
+function normalizeSeoPath(pathname: string): string {
+  const pathOnly = pathname.split('?')[0].split('#')[0] || '/';
+
+  if (pathOnly === '/') {
+    return '/';
+  }
+
+  return pathOnly.replace(/\/+$/, '') || '/';
+}
+
 export function getPublicSeoRoute(pathname: string, baseUrl: string): SeoRouteData {
-  const cleanPath = pathname.split('?')[0].split('#')[0] || '/';
+  const cleanPath = normalizeSeoPath(pathname);
 
   if (cleanPath === '/') {
     return {


### PR DESCRIPTION
## What does this PR do?

Brief description of the changes.

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] Code compiles without errors (`npx tsc --noEmit`)
- [ ] Client builds successfully (`npm run build --workspace=client`)
- [ ] Tested locally
- [ ] No console errors in browser
