### PR TITLE
feat: declutter home UX and normalize UI surfaces

### DIFF
--- a/client/e2e/home.spec.ts
+++ b/client/e2e/home.spec.ts
@@ -14,7 +14,7 @@ test.describe('Homepage', () => {
     await expect(page).toHaveTitle(/ThaiChess/);
 
     const main = page.locator('#main-content');
-    const createPrivateButton = main.getByRole('button', { name: /create a private game/i });
+    const createPrivateButton = main.getByRole('button', { name: /create a private game/i }).first();
 
     await expect(createPrivateButton).toBeVisible();
     await createPrivateButton.click();

--- a/client/src/components/AboutPage.tsx
+++ b/client/src/components/AboutPage.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from '../lib/i18n';
 import { routes } from '../lib/routes';
 import { useQuery } from '@tanstack/react-query';
+import Footer from './Footer';
 import Header from './Header';
 import PieceSVG from './PieceSVG';
 import { aboutStatsQueryOptions } from '../queries/stats';
@@ -176,74 +177,7 @@ export default function AboutPage() {
         </div>
       </main>
 
-      <footer className="bg-surface-alt border-t border-surface-hover py-8 px-4">
-        <div className="max-w-6xl mx-auto">
-          {/* Support Section */}
-          <div className="mb-6 p-4 rounded-xl border border-accent/20 bg-accent/5">
-            <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
-              <div className="text-center sm:text-left">
-                <p className="text-text-bright font-semibold text-sm">{t('footer.support')}</p>
-                <p className="text-text-dim text-xs mt-1 max-w-md">{t('footer.support_desc')}</p>
-              </div>
-              <a
-                href="/donate-qr.jpg"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 rounded-xl bg-[#4B0082] px-5 py-2.5 text-sm font-semibold text-white transition-all hover:bg-[#4B0082]/85 hover:scale-105 whitespace-nowrap"
-              >
-                <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
-                  <path d="M3 3h6v6H3V3zm2 2v2h2V5H5zm8-2h6v6h-6V3zm2 2v2h2V5h-2zM3 11h6v6H3v-6zm2 2v2h2v-2H5zm13-2h3v3h-3v-3zm-2 2h3v3h-3v-3zm2 2h3v3h-3v-3zm-9 2h3v3H9v-3zm2 2h3v3h-3v-3zm-2 2h3v3H9v-3z"/>
-                </svg>
-                {t('footer.donate_thai')}
-              </a>
-            </div>
-            {/* Bank Info */}
-            <div className="mt-3 pt-3 border-t border-accent/10 text-center">
-              <p className="text-text-dim/80 text-xs">{t('footer.bank_info')}</p>
-            </div>
-          </div>
-
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-6 sm:gap-8 mb-6">
-            {/* Play */}
-            <div>
-              <h4 className="text-text-bright font-semibold mb-3 text-sm">{t('nav.play')}</h4>
-              <ul className="space-y-2 text-text-dim text-xs">
-                <li><a href="/quick-play" className="hover:text-primary transition-colors">{t('home.quick_play')}</a></li>
-                <li><a href="/local" className="hover:text-primary transition-colors">{t('home.play_local')}</a></li>
-                <li><a href="/bot" className="hover:text-primary transition-colors">{t('home.play_bot')}</a></li>
-              </ul>
-            </div>
-            {/* Puzzles */}
-            <div>
-              <h4 className="text-text-bright font-semibold mb-3 text-sm">{t('nav.puzzles')}</h4>
-              <ul className="space-y-2 text-text-dim text-xs">
-                <li><a href={routes.puzzles} className="hover:text-primary transition-colors">{t('nav.puzzles_random')}</a></li>
-                <li><a href={routes.puzzleStreak} className="hover:text-primary transition-colors">{t('nav.puzzles_streak')}</a></li>
-              </ul>
-            </div>
-            {/* About */}
-            <div>
-              <h4 className="text-text-bright font-semibold mb-3 text-sm">{t('nav.about')}</h4>
-              <ul className="space-y-2 text-text-dim text-xs">
-                <li><a href="/games" className="hover:text-primary transition-colors">{t('games.title')}</a></li>
-                <li><a href="https://github.com/ChindanaiNaKub/thaichess" target="_blank" rel="noopener" className="hover:text-primary transition-colors">{t('footer.github')}</a></li>
-              </ul>
-            </div>
-            {/* Community */}
-            <div>
-              <h4 className="text-text-bright font-semibold mb-3 text-sm">{t('footer.community')}</h4>
-              <ul className="space-y-2 text-text-dim text-xs">
-                <li><a href="https://github.com/ChindanaiNaKub/thaichess" target="_blank" rel="noopener" className="hover:text-primary transition-colors">{t('footer.star_github')}</a></li>
-                <li><a href="/feedback" className="hover:text-primary transition-colors">{t('feedback.button')}</a></li>
-              </ul>
-            </div>
-          </div>
-          <div className="pt-6 border-t border-surface-hover text-center">
-            <p className="text-text-dim text-xs">{t('about.footer')}</p>
-            <p className="text-text-dim/70 text-xs mt-2">{t('footer.thanks')}</p>
-          </div>
-        </div>
-      </footer>
+      <Footer />
     </div>
   );
 }

--- a/client/src/components/FeedbackMessagesPage.tsx
+++ b/client/src/components/FeedbackMessagesPage.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { useAuth } from '../lib/auth';
 import { useTranslation } from '../lib/i18n';
-import { routes } from '../lib/routes';
+import Footer from './Footer';
 import Header from './Header';
 import { feedbackQueryOptions, type FeedbackEntry, type FilterType } from '../queries/feedback';
 
@@ -210,48 +210,7 @@ export default function FeedbackMessagesPage() {
         )}
       </main>
 
-      <footer className="bg-surface-alt border-t border-surface-hover py-8 px-4">
-        <div className="max-w-6xl mx-auto">
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-6 sm:gap-8 mb-6">
-            {/* Play */}
-            <div>
-              <h4 className="text-text-bright font-semibold mb-3 text-sm">{t('nav.play')}</h4>
-              <ul className="space-y-2 text-text-dim text-xs">
-                <li><a href="/quick-play" className="hover:text-primary transition-colors">{t('home.quick_play')}</a></li>
-                <li><a href="/local" className="hover:text-primary transition-colors">{t('home.play_local')}</a></li>
-                <li><a href="/bot" className="hover:text-primary transition-colors">{t('home.play_bot')}</a></li>
-              </ul>
-            </div>
-            {/* Puzzles */}
-            <div>
-              <h4 className="text-text-bright font-semibold mb-3 text-sm">{t('nav.puzzles')}</h4>
-              <ul className="space-y-2 text-text-dim text-xs">
-                <li><a href={routes.puzzles} className="hover:text-primary transition-colors">{t('nav.puzzles_random')}</a></li>
-                <li><a href={routes.puzzleStreak} className="hover:text-primary transition-colors">{t('nav.puzzles_streak')}</a></li>
-              </ul>
-            </div>
-            {/* About */}
-            <div>
-              <h4 className="text-text-bright font-semibold mb-3 text-sm">{t('nav.about')}</h4>
-              <ul className="space-y-2 text-text-dim text-xs">
-                <li><a href="/games" className="hover:text-primary transition-colors">{t('games.title')}</a></li>
-                <li><a href="https://github.com/ChindanaiNaKub/thaichess" target="_blank" rel="noopener" className="hover:text-primary transition-colors">{t('footer.github')}</a></li>
-              </ul>
-            </div>
-            {/* Community */}
-            <div>
-              <h4 className="text-text-bright font-semibold mb-3 text-sm">{t('footer.community')}</h4>
-              <ul className="space-y-2 text-text-dim text-xs">
-                <li><a href="https://github.com/ChindanaiNaKub/thaichess" target="_blank" rel="noopener" className="hover:text-primary transition-colors">{t('footer.star_github')}</a></li>
-                <li><a href="/feedback" className="hover:text-primary transition-colors">{t('feedback.button')}</a></li>
-              </ul>
-            </div>
-          </div>
-          <div className="pt-6 border-t border-surface-hover text-center">
-            <p className="text-text-dim text-xs">{t('footer.tagline')}</p>
-          </div>
-        </div>
-      </footer>
+      <Footer />
     </div>
   );
 }

--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -8,7 +8,7 @@ export default function Footer() {
     <footer className="bg-surface-alt border-t border-surface-hover py-6 px-4">
       <div className="max-w-6xl mx-auto">
         {/* Support Section */}
-        <div className="mb-6 p-4 rounded-xl border border-accent/20 bg-accent/5">
+        <div className="ui-card mb-6 p-4 border-accent/20 bg-accent/5">
           <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
             <div className="text-center sm:text-left">
               <p className="text-text-bright font-semibold text-sm">{t('footer.support')}</p>
@@ -18,7 +18,7 @@ export default function Footer() {
               href="/donate-qr.jpg"
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 rounded-xl bg-[#4B0082] px-5 py-2.5 text-sm font-semibold text-white transition-all hover:bg-[#4B0082]/85 hover:scale-105 whitespace-nowrap"
+              className="inline-flex items-center gap-2 rounded-xl bg-[#4B0082] px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[#4B0082]/85 whitespace-nowrap"
             >
               <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
                 <path d="M3 3h6v6H3V3zm2 2v2h2V5H5zm8-2h6v6h-6V3zm2 2v2h2V5h-2zM3 11h6v6H3v-6zm2 2v2h2v-2H5zm13-2h3v3h-3v-3zm-2 2h3v3h-3v-3zm2 2h3v3h-3v-3zm-9 2h3v3H9v-3zm2 2h3v3h-3v-3zm-2 2h3v3H9v-3z"/>

--- a/client/src/components/GamesPage.tsx
+++ b/client/src/components/GamesPage.tsx
@@ -5,12 +5,7 @@ import { useTranslation } from '../lib/i18n';
 import { routes, savedGameAnalysisRoute } from '../lib/routes';
 import { gamesQueryOptions, type GamesFilter, type GameEntry } from '../queries/games';
 import Header from './Header';
-
-interface BotPerformanceStats {
-  gamesCount: number;
-  winRate: number;
-  highestBotLevelDefeated: number | null;
-}
+import Footer from './Footer';
 
 function formatTimeControl(initial: number, increment: number): string {
   const mins = Math.floor(initial / 60);
@@ -158,7 +153,7 @@ function renderGameRow(
       <td className="px-3 sm:px-4 py-3 text-right">
         <button
           onClick={(e) => { e.stopPropagation(); navigate(savedGameAnalysisRoute(game.id)); }}
-          className="px-2.5 py-1 rounded-md border border-primary/20 bg-primary/10 hover:bg-primary/20 text-primary-light text-xs font-semibold transition-colors"
+          className="ui-btn-primary px-2.5 py-1 text-xs"
           title={t('analysis.analyze')}
         >
           {t('analysis.view')}
@@ -187,7 +182,6 @@ export default function GamesPage() {
     isLoading,
     isError,
     error,
-    isPlaceholderData,
   } = useQuery(gamesQueryOptions(page, limit, filter));
 
   const games = data?.games ?? [];
@@ -207,14 +201,14 @@ export default function GamesPage() {
       <Header active="games" />
 
       <main id="main-content" className="flex-1 max-w-5xl mx-auto px-4 sm:px-6 py-4 sm:py-6 w-full">
-        <div className="rounded-2xl border border-surface-hover bg-surface-alt/80 px-4 py-4 sm:px-5 sm:py-5 mb-4 sm:mb-6">
+        <div className="ui-card mb-4 px-4 py-4 sm:mb-6 sm:px-5 sm:py-5">
           <div className="flex flex-col gap-3">
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
               <div className="flex items-center gap-3">
-                <h2 className="text-xl sm:text-2xl font-bold text-text-bright">{t('games.title')}</h2>
+                <h2 className="ui-title text-xl sm:text-2xl">{t('games.title')}</h2>
                 <button
                   onClick={() => navigate(routes.leaderboard)}
-                  className="px-3 py-1.5 rounded-lg border border-surface-hover bg-surface text-text-bright text-xs sm:text-sm font-semibold hover:bg-surface-hover transition-colors"
+                  className="ui-btn-secondary px-3 py-1.5 text-xs sm:text-sm"
                 >
                   {t('games.view_leaderboard')}
                 </button>
@@ -230,7 +224,7 @@ export default function GamesPage() {
                   className={`rounded-full px-3 py-1.5 text-xs sm:text-sm font-semibold transition-colors ${
                     filter === filterOption
                       ? 'bg-primary text-white'
-                      : 'border border-surface-hover bg-surface text-text-dim hover:bg-surface-hover'
+                      : 'ui-btn-secondary text-text-dim hover:text-text-bright'
                   }`}
                 >
                   {t(`games.filter_${filterOption}`)}
@@ -238,15 +232,15 @@ export default function GamesPage() {
               ))}
             </div>
             <div className="grid gap-2 sm:grid-cols-3">
-              <div className="rounded-xl border border-surface-hover bg-surface/65 px-3 py-3">
+              <div className="ui-card-soft px-3 py-3">
                 <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-text-dim">{t('games.bot_games')}</div>
                 <div className="mt-1 text-lg font-semibold text-text-bright">{botStats.gamesCount}</div>
               </div>
-              <div className="rounded-xl border border-surface-hover bg-surface/65 px-3 py-3">
+              <div className="ui-card-soft px-3 py-3">
                 <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-text-dim">{t('games.bot_win_rate')}</div>
                 <div className="mt-1 text-lg font-semibold text-text-bright">{botStats.winRate}%</div>
               </div>
-              <div className="rounded-xl border border-surface-hover bg-surface/65 px-3 py-3">
+              <div className="ui-card-soft px-3 py-3">
                 <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-text-dim">{t('games.bot_highest_level')}</div>
                 <div className="mt-1 text-lg font-semibold text-text-bright">
                   {botStats.highestBotLevelDefeated ? `Lv.${botStats.highestBotLevelDefeated}` : '-'}
@@ -261,30 +255,30 @@ export default function GamesPage() {
             <div className="w-10 h-10 border-4 border-primary border-t-transparent rounded-full animate-spin" />
           </div>
         ) : isError ? (
-          <div className="rounded-2xl border border-danger/30 bg-danger/10 px-6 py-10 text-center">
+          <div className="ui-card rounded-2xl border-danger/30 bg-danger/10 px-6 py-10 text-center">
             <p className="text-danger">{error?.message || t('error.generic')}</p>
             <button
               onClick={() => window.location.reload()}
-              className="mt-4 px-4 py-2 bg-primary text-white rounded-lg"
+              className="ui-btn-primary mt-4 px-4 py-2"
             >
               {t('common.retry')}
             </button>
           </div>
         ) : games.length === 0 ? (
-          <div className="rounded-2xl border border-surface-hover bg-surface-alt px-6 py-10 sm:px-10 sm:py-12 text-center">
+          <div className="ui-card rounded-2xl px-6 py-10 text-center sm:px-10 sm:py-12">
             <div className="text-4xl mb-4">♟</div>
             <p className="text-text-bright text-lg sm:text-xl font-semibold mb-2">{t('games.empty')}</p>
             <p className="text-text-dim text-sm sm:text-base mb-6 max-w-md mx-auto">{t('games.empty_desc')}</p>
             <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
               <button
                 onClick={() => navigate(routes.quickPlay)}
-                className="w-full sm:w-auto px-5 sm:px-6 py-2.5 sm:py-3 bg-primary hover:bg-primary-light text-white font-semibold rounded-lg transition-colors text-sm sm:text-base"
+                className="ui-btn-primary w-full px-5 py-2.5 text-sm sm:w-auto sm:px-6 sm:py-3 sm:text-base"
               >
                 {t('home.find_opponent')}
               </button>
               <button
                 onClick={() => navigate(routes.puzzles)}
-                className="w-full sm:w-auto px-5 sm:px-6 py-2.5 sm:py-3 bg-surface hover:bg-surface-hover text-text-bright font-semibold rounded-lg border border-surface-hover transition-colors text-sm sm:text-base"
+                className="ui-btn-secondary w-full px-5 py-2.5 text-sm sm:w-auto sm:px-6 sm:py-3 sm:text-base"
               >
                 {t('nav.puzzles')}
               </button>
@@ -293,18 +287,18 @@ export default function GamesPage() {
         ) : (
           <>
             {highlightedGames.length > 0 ? (
-              <div className="mb-3 rounded-2xl border border-primary/15 bg-primary/5 px-4 py-3 sm:px-5">
+              <div className="ui-card-soft mb-3 rounded-2xl border-primary/15 bg-primary/5 px-4 py-3 sm:px-5">
                 <p className="text-sm font-semibold text-text-bright">{t('games.featured_title')}</p>
                 <p className="mt-1 text-xs sm:text-sm text-text-dim">{t('games.featured_desc')}</p>
               </div>
             ) : (
-              <div className="mb-3 rounded-2xl border border-surface-hover bg-surface-alt px-4 py-3 sm:px-5">
+              <div className="ui-card-soft mb-3 rounded-2xl px-4 py-3 sm:px-5">
                 <p className="text-sm font-semibold text-text-bright">{t('games.no_featured_title')}</p>
                 <p className="mt-1 text-xs sm:text-sm text-text-dim">{t('games.no_featured_desc')}</p>
               </div>
             )}
 
-            <div className="bg-surface-alt rounded-xl border border-surface-hover overflow-x-auto">
+            <div className="ui-card overflow-x-auto rounded-xl">
               <table className="w-full text-sm min-w-[320px]">
                 <thead>
                   <tr className="border-b border-surface-hover text-text-dim text-left">
@@ -323,7 +317,7 @@ export default function GamesPage() {
             </div>
 
             {lowSignalGames.length > 0 && (
-              <div className="mt-4 rounded-xl border border-surface-hover bg-surface-alt/70">
+              <div className="ui-card mt-4 rounded-xl bg-surface-alt/70">
                 <div className="border-b border-surface-hover px-4 py-3 sm:px-5">
                   <p className="text-sm font-semibold text-text-bright">{t('games.low_signal_title')}</p>
                   <p className="mt-1 text-xs sm:text-sm text-text-dim">{t('games.low_signal_desc')}</p>
@@ -343,7 +337,7 @@ export default function GamesPage() {
                 <button
                   onClick={() => setPage(p => Math.max(0, p - 1))}
                   disabled={page === 0}
-                  className="px-3 py-1.5 bg-surface-alt border border-surface-hover rounded text-sm disabled:opacity-30 hover:bg-surface-hover transition-colors text-text"
+                  className="ui-btn-secondary px-3 py-1.5 text-sm text-text disabled:opacity-30"
                 >
                   ← {t('games.prev')}
                 </button>
@@ -353,7 +347,7 @@ export default function GamesPage() {
                 <button
                   onClick={() => setPage(p => Math.min(totalPages - 1, p + 1))}
                   disabled={page >= totalPages - 1}
-                  className="px-3 py-1.5 bg-surface-alt border border-surface-hover rounded text-sm disabled:opacity-30 hover:bg-surface-hover transition-colors text-text"
+                  className="ui-btn-secondary px-3 py-1.5 text-sm text-text disabled:opacity-30"
                 >
                   {t('games.next')} →
                 </button>
@@ -363,49 +357,7 @@ export default function GamesPage() {
         )}
       </main>
 
-      <footer className="bg-surface-alt border-t border-surface-hover py-8 px-4">
-        <div className="max-w-6xl mx-auto">
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-6 sm:gap-8 mb-6">
-            {/* Play */}
-            <div>
-              <h4 className="text-text-bright font-semibold mb-3 text-sm">{t('nav.play')}</h4>
-              <ul className="space-y-2 text-text-dim text-xs">
-                <li><a href="/quick-play" className="hover:text-primary transition-colors">{t('home.quick_play')}</a></li>
-                <li><a href="/local" className="hover:text-primary transition-colors">{t('home.play_local')}</a></li>
-                <li><a href="/bot" className="hover:text-primary transition-colors">{t('home.play_bot')}</a></li>
-              </ul>
-            </div>
-            {/* Puzzles */}
-            <div>
-              <h4 className="text-text-bright font-semibold mb-3 text-sm">{t('nav.puzzles')}</h4>
-              <ul className="space-y-2 text-text-dim text-xs">
-                <li><a href={routes.puzzles} className="hover:text-primary transition-colors">{t('nav.puzzles_random')}</a></li>
-                <li><a href={routes.puzzleStreak} className="hover:text-primary transition-colors">{t('nav.puzzles_streak')}</a></li>
-              </ul>
-            </div>
-            {/* About */}
-            <div>
-              <h4 className="text-text-bright font-semibold mb-3 text-sm">{t('nav.about')}</h4>
-              <ul className="space-y-2 text-text-dim text-xs">
-                <li><a href="/games" className="hover:text-primary transition-colors">{t('games.title')}</a></li>
-                <li><a href="/leaderboard" className="hover:text-primary transition-colors">{t('leaderboard.title')}</a></li>
-                <li><a href="https://github.com/ChindanaiNaKub/thaichess" target="_blank" rel="noopener" className="hover:text-primary transition-colors">{t('footer.github')}</a></li>
-              </ul>
-            </div>
-            {/* Community */}
-            <div>
-              <h4 className="text-text-bright font-semibold mb-3 text-sm">{t('footer.community')}</h4>
-              <ul className="space-y-2 text-text-dim text-xs">
-                <li><a href="https://github.com/ChindanaiNaKub/thaichess" target="_blank" rel="noopener" className="hover:text-primary transition-colors">{t('footer.star_github')}</a></li>
-                <li><a href="/feedback" className="hover:text-primary transition-colors">{t('feedback.button')}</a></li>
-              </ul>
-            </div>
-          </div>
-          <div className="pt-6 border-t border-surface-hover text-center">
-            <p className="text-text-dim text-xs">{t('footer.tagline')}</p>
-          </div>
-        </div>
-      </footer>
+      <Footer />
     </div>
   );
 }

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { type ReactNode, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../lib/auth';
 import { useTranslation } from '../lib/i18n';
@@ -10,7 +10,7 @@ import AppearanceSettingsButton from './AppearanceSettingsButton';
 interface HeaderProps {
   active?: 'play' | 'watch' | 'lessons' | 'puzzles' | 'games' | 'about' | null;
   subtitle?: string;
-  right?: React.ReactNode;
+  right?: ReactNode;
 }
 
 export default function Header({ active, subtitle, right }: HeaderProps) {
@@ -19,7 +19,7 @@ export default function Header({ active, subtitle, right }: HeaderProps) {
   const { user, loading } = useAuth();
   const [menuOpen, setMenuOpen] = useState(false);
   const [puzzleMenuOpen, setPuzzleMenuOpen] = useState(false);
-  const { prefetchGames, prefetchLeaderboard, prefetchAboutStats, prefetchFeedback } = usePrefetchQueries();
+  const { prefetchLeaderboard, prefetchFeedback } = usePrefetchQueries();
 
   const handleNavigate = (path: string) => {
     setMenuOpen(false);
@@ -114,8 +114,6 @@ export default function Header({ active, subtitle, right }: HeaderProps) {
                   </div>
                 )}
               </div>
-              {navItem('games', routes.games, t('nav.games'), prefetchGames)}
-              {navItem('about', routes.about, t('nav.about'), prefetchAboutStats)}
             </nav>
           )}
 
@@ -123,46 +121,46 @@ export default function Header({ active, subtitle, right }: HeaderProps) {
             {right}
           </div>
 
-          {!loading && (
-            user ? (
-              <div className="flex items-center gap-2">
-                {user.role === 'admin' && (
+          <div className="hidden sm:flex items-center gap-2">
+            {!loading && (
+              user ? (
+                <>
+                  {user.role === 'admin' && (
+                    <button
+                      onClick={() => handleNavigate('/feedback')}
+                      onMouseEnter={prefetchFeedback}
+                      className="h-7 rounded-md border border-surface-hover/60 bg-surface px-2.5 text-xs font-semibold text-text-dim transition-colors hover:text-text-bright"
+                    >
+                      {t('header.admin')}
+                    </button>
+                  )}
                   <button
-                    onClick={() => handleNavigate('/feedback')}
-                    onMouseEnter={prefetchFeedback}
-                    className="hidden sm:inline h-7 px-2.5 rounded-md border border-surface-hover/60 bg-surface text-text-dim hover:text-text-bright text-xs font-semibold"
+                    onClick={() => handleNavigate('/account')}
+                    className="h-7 rounded-md border border-surface-hover/60 bg-surface px-2.5 text-xs font-semibold text-text-dim transition-colors hover:text-text-bright"
                   >
-                    {t('header.admin')}
+                    {user.username || user.email.split('@')[0]}
                   </button>
-                )}
+                </>
+              ) : (
                 <button
-                  onClick={() => handleNavigate('/account')}
-                  className="h-7 px-2.5 rounded-md border border-surface-hover/60 bg-surface text-text-dim hover:text-text-bright text-xs font-semibold"
+                  onClick={() => handleNavigate('/login')}
+                  className="button-primary-contrast h-7 rounded-md px-2.5 text-xs font-semibold tracking-wide"
                 >
-                  {user.username || user.email.split('@')[0]}
+                  {t('header.sign_in')}
                 </button>
-              </div>
-            ) : (
-              <button
-                onClick={() => handleNavigate('/login')}
-                className="button-primary-contrast h-7 px-2.5 rounded-md text-xs font-semibold tracking-wide transition-all duration-150 active:scale-95"
-              >
-                {t('header.sign_in')}
-              </button>
-            )
-          )}
+              )
+            )}
 
-          <div className="hidden sm:block">
             <AppearanceSettingsButton compact />
-          </div>
 
-          <button
-            onClick={() => setLang(lang === 'en' ? 'th' : 'en')}
-            className="hidden sm:inline-flex h-7 px-2.5 rounded-md bg-surface hover:bg-surface-hover border border-surface-hover/60 text-text-dim hover:text-text-bright text-xs font-semibold tracking-wide transition-all duration-150 active:scale-95"
-            title={lang === 'en' ? t('header.switch_to_th') : t('header.switch_to_en')}
-          >
-            {t('lang.switch')}
-          </button>
+            <button
+              onClick={() => setLang(lang === 'en' ? 'th' : 'en')}
+              className="inline-flex h-7 rounded-md border border-surface-hover/60 bg-surface px-2.5 text-xs font-semibold tracking-wide text-text-dim transition-colors hover:bg-surface-hover hover:text-text-bright"
+              title={lang === 'en' ? t('header.switch_to_th') : t('header.switch_to_en')}
+            >
+              {t('lang.switch')}
+            </button>
+          </div>
 
           <div className="flex items-center gap-2 sm:hidden">
             {right}
@@ -190,11 +188,16 @@ export default function Header({ active, subtitle, right }: HeaderProps) {
                 {mobileNavItem('puzzles', routes.puzzles, t('nav.puzzles_random'))}
                 {mobileNavItem('puzzles', routes.puzzleStreak, t('nav.puzzles_streak'))}
                 {mobileNavItem('games', routes.games, t('nav.games'))}
-                {mobileNavItem('about', routes.about, t('nav.about'))}
               </nav>
             )}
 
             <div className="grid gap-3">
+              <button
+                onClick={() => handleNavigate(routes.about)}
+                className="inline-flex h-9 items-center justify-center rounded-md border border-surface-hover/60 bg-surface px-3 text-sm font-semibold text-text-bright transition-colors hover:bg-surface-hover"
+              >
+                {t('nav.about')}
+              </button>
               <AppearanceSettingsButton className="w-full justify-center" />
 
               <button

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -52,10 +52,10 @@ export default function Header({ active, subtitle, right }: HeaderProps) {
       key={key}
       onClick={() => handleNavigate(path)}
       className={`
-        rounded-lg border px-3 py-2 text-left text-sm font-semibold transition-colors
+        ui-btn-secondary px-3 py-2 text-left text-sm
         ${active === key
           ? 'border-primary/40 bg-primary/12 text-primary-light'
-          : 'border-surface-hover/60 bg-surface text-text-bright hover:bg-surface-hover'
+          : ''
         }
       `}
     >
@@ -129,14 +129,14 @@ export default function Header({ active, subtitle, right }: HeaderProps) {
                     <button
                       onClick={() => handleNavigate('/feedback')}
                       onMouseEnter={prefetchFeedback}
-                      className="h-7 rounded-md border border-surface-hover/60 bg-surface px-2.5 text-xs font-semibold text-text-dim transition-colors hover:text-text-bright"
+                      className="ui-btn-secondary h-7 px-2.5 text-xs text-text-dim hover:text-text-bright"
                     >
                       {t('header.admin')}
                     </button>
                   )}
                   <button
                     onClick={() => handleNavigate('/account')}
-                    className="h-7 rounded-md border border-surface-hover/60 bg-surface px-2.5 text-xs font-semibold text-text-dim transition-colors hover:text-text-bright"
+                    className="ui-btn-secondary h-7 px-2.5 text-xs text-text-dim hover:text-text-bright"
                   >
                     {user.username || user.email.split('@')[0]}
                   </button>
@@ -155,7 +155,7 @@ export default function Header({ active, subtitle, right }: HeaderProps) {
 
             <button
               onClick={() => setLang(lang === 'en' ? 'th' : 'en')}
-              className="inline-flex h-7 rounded-md border border-surface-hover/60 bg-surface px-2.5 text-xs font-semibold tracking-wide text-text-dim transition-colors hover:bg-surface-hover hover:text-text-bright"
+              className="ui-btn-secondary inline-flex h-7 px-2.5 text-xs tracking-wide text-text-dim hover:text-text-bright"
               title={lang === 'en' ? t('header.switch_to_th') : t('header.switch_to_en')}
             >
               {t('lang.switch')}
@@ -167,7 +167,7 @@ export default function Header({ active, subtitle, right }: HeaderProps) {
             <button
               type="button"
               onClick={() => setMenuOpen((open) => !open)}
-              className="inline-flex h-8 items-center rounded-md border border-surface-hover/60 bg-surface px-2.5 text-xs font-semibold tracking-wide text-text-bright transition-colors hover:bg-surface-hover"
+              className="ui-btn-secondary inline-flex h-8 items-center px-2.5 text-xs tracking-wide"
               aria-expanded={menuOpen}
               aria-controls="mobile-site-menu"
             >
@@ -194,7 +194,7 @@ export default function Header({ active, subtitle, right }: HeaderProps) {
             <div className="grid gap-3">
               <button
                 onClick={() => handleNavigate(routes.about)}
-                className="inline-flex h-9 items-center justify-center rounded-md border border-surface-hover/60 bg-surface px-3 text-sm font-semibold text-text-bright transition-colors hover:bg-surface-hover"
+                className="ui-btn-secondary inline-flex h-9 items-center justify-center px-3 text-sm"
               >
                 {t('nav.about')}
               </button>
@@ -202,7 +202,7 @@ export default function Header({ active, subtitle, right }: HeaderProps) {
 
               <button
                 onClick={() => setLang(lang === 'en' ? 'th' : 'en')}
-                className="inline-flex h-9 items-center justify-center rounded-md border border-surface-hover/60 bg-surface px-3 text-sm font-semibold text-text-bright transition-colors hover:bg-surface-hover"
+                className="ui-btn-secondary inline-flex h-9 items-center justify-center px-3 text-sm"
                 title={lang === 'en' ? t('header.switch_to_th') : t('header.switch_to_en')}
               >
                 {t('lang.switch')}

--- a/client/src/components/HomePage.tsx
+++ b/client/src/components/HomePage.tsx
@@ -13,8 +13,6 @@ import { useTranslation } from '../lib/i18n';
 import { usePublicLiveGames } from '../hooks/usePublicLiveGames';
 import { usePrefetchQueries } from '../hooks/usePrefetchQueries';
 
-import PieceSVG from './PieceSVG';
-
 import Header from './Header';
 
 import FriendSVG from './FriendSVG';
@@ -27,8 +25,7 @@ import QuickPlaySVG from './QuickPlaySVG';
 import Footer from './Footer';
 const DeferredLiveGamesPanel = lazy(() => import('./LiveGamesPanel'));
 
-import type { PieceType, PieceColor, PrivateGameColorPreference } from '@shared/types';
-
+import type { PrivateGameColorPreference } from '@shared/types';
 const TIME_PRESETS = [
   { label: '1+0', nameKey: 'time.bullet', initial: 60, increment: 0 },
   { label: '3+0', nameKey: 'time.blitz', initial: 180, increment: 0 },
@@ -39,15 +36,6 @@ const TIME_PRESETS = [
   { label: '10+5', nameKey: 'time.rapid', initial: 600, increment: 5 },
   { label: '15+10', nameKey: 'time.classical', initial: 900, increment: 10 },
   { label: '30+0', nameKey: 'time.classical', initial: 1800, increment: 0 },
-];
-
-const SHOWCASE_PIECES: { type: PieceType; color: PieceColor }[] = [
-  { type: 'R', color: 'white' },
-  { type: 'N', color: 'white' },
-  { type: 'S', color: 'white' },
-  { type: 'M', color: 'white' },
-  { type: 'K', color: 'white' },
-  { type: 'P', color: 'white' },
 ];
 
 type SocketModule = typeof import('../lib/socket');
@@ -63,11 +51,10 @@ export default function HomePage() {
   const [isCreating, setIsCreating] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
   const [joinId, setJoinId] = useState('');
-  const [showCreate, setShowCreate] = useState(false);
+  const [showCreate, setShowCreate] = useState(true);
   const [showJoin, setShowJoin] = useState(false);
   const [deferredContentReady, setDeferredContentReady] = useState(import.meta.env.MODE === 'test');
   const [showDeferredContent, setShowDeferredContent] = useState(false);
-  const [showHeroDecor, setShowHeroDecor] = useState(import.meta.env.MODE === 'test');
   const { games: liveGames, loading: liveGamesLoading } = usePublicLiveGames({ status: 'live', limit: 4, enabled: showDeferredContent });
   
   // Use TanStack Query for stats
@@ -140,29 +127,6 @@ export default function HomePage() {
     window.addEventListener('load', markReady, { once: true });
     return () => window.removeEventListener('load', markReady);
   }, [deferredContentReady]);
-
-  useEffect(() => {
-    if (showHeroDecor || !deferredContentReady || typeof window === 'undefined') return;
-
-    let idleId: number | undefined;
-    let timeoutId: number | undefined;
-    const requestIdle = window.requestIdleCallback;
-
-    if (typeof requestIdle === 'function') {
-      idleId = requestIdle(() => setShowHeroDecor(true), { timeout: 1_200 });
-    } else {
-      timeoutId = window.setTimeout(() => setShowHeroDecor(true), 250);
-    }
-
-    return () => {
-      if (idleId !== undefined) {
-        window.cancelIdleCallback?.(idleId);
-      }
-      if (timeoutId !== undefined) {
-        window.clearTimeout(timeoutId);
-      }
-    };
-  }, [deferredContentReady, showHeroDecor]);
 
   useEffect(() => {
     if (showDeferredContent || !deferredContentReady) return;
@@ -282,210 +246,130 @@ export default function HomePage() {
 
       <main id="main-content" className="flex-1 px-4 py-8 sm:px-6 sm:py-10">
         <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 sm:gap-8">
-          <section className="grid gap-4 lg:grid-cols-[minmax(0,1.4fr)_320px] xl:grid-cols-[minmax(0,1.55fr)_340px]">
-            <div className="bg-surface-alt border border-accent/30 rounded-2xl p-6 sm:p-8 lg:p-10">
-              <div className="mb-4 flex min-h-10 items-center justify-center gap-1 sm:mb-5">
-                {showHeroDecor ? SHOWCASE_PIECES.map((p, i) => (
-                  <div key={i} className="opacity-80 hover:opacity-100 transition-opacity">
-                    <PieceSVG type={p.type} color={p.color} size={40} />
-                  </div>
-                )) : null}
+          <section className="grid gap-4 lg:grid-cols-[minmax(0,1.45fr)_330px]">
+            <div className="rounded-2xl border border-surface-hover/70 bg-surface-alt p-6 sm:p-8 lg:p-10">
+              <p className="text-xs font-semibold uppercase tracking-[0.22em] text-accent">
+                {t('nav.play')}
+              </p>
+
+              <h1 className="mt-3 max-w-3xl text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-text-bright">
+                {t('home.hero_title')}
+              </h1>
+              <p className="mt-4 max-w-2xl text-base sm:text-lg text-text-dim leading-7">
+                {t('home.hero_desc')}
+              </p>
+
+              <div className="mt-7 flex flex-wrap gap-2">
+                <span className="rounded-full border border-surface-hover/70 bg-surface px-3 py-1 text-xs font-semibold text-text-dim">
+                  {t('home.no_signup')}
+                </span>
+                <span className="rounded-full border border-surface-hover/70 bg-surface px-3 py-1 text-xs font-semibold text-text-dim">
+                  {t('home.free_to_play')}
+                </span>
+                <span className="rounded-full border border-surface-hover/70 bg-surface px-3 py-1 text-xs font-semibold text-text-dim">
+                  {stats ? t('home.games_played', { count: stats.totalGames }) : t('home.games_played', { count: 0 })}
+                </span>
               </div>
 
-              <div className="mx-auto max-w-2xl text-center">
-                <h1 className="text-3xl sm:text-4xl lg:text-[3.35rem] display text-text-bright mb-3">
-                  {t('home.hero_title')}
-                </h1>
-                <p className="text-text-dim text-base sm:text-lg max-w-2xl mx-auto">
-                  {t('home.hero_desc')}
-                </p>
-              </div>
-
-              <div className="mt-8 sm:mt-10 rounded-2xl border border-accent/20 bg-surface/75 p-5 sm:p-6 lg:p-7 shadow-[0_20px_50px_rgba(0,0,0,0.16)]">
-                <div className="flex items-start justify-between gap-4 mb-4">
-                  <div>
-                    <p className="text-xs font-semibold uppercase tracking-[0.22em] text-accent mb-2">
-                      {t('nav.play')}
-                    </p>
-                    <h2 className="display text-3xl text-text-bright">{t('home.quick_play')}</h2>
-                    <p className="text-text-dim text-sm sm:text-base mt-2 max-w-lg">{t('home.quick_play_desc')}</p>
-                  </div>
-                  <QuickPlaySVG size={46} className="text-text-bright flex-shrink-0" />
-                </div>
-
-                <div className="flex flex-wrap justify-center sm:justify-start gap-2 mb-6">
-                  <span className="rounded-full border border-surface-hover bg-surface px-3 py-1 text-xs font-semibold text-text-dim">
-                    {t('home.no_signup')}
-                  </span>
-                  <span className="rounded-full border border-surface-hover bg-surface px-3 py-1 text-xs font-semibold text-text-dim">
-                    {t('home.free_to_play')}
-                  </span>
-                  <span
-                    aria-hidden={stats === null}
-                    className={`rounded-full border border-surface-hover bg-surface px-3 py-1 text-xs font-semibold text-text-dim transition-opacity ${stats && stats.totalGames > 0 ? 'opacity-100' : 'opacity-0'}`}
-                  >
-                    {stats && stats.totalGames > 0 ? t('home.games_played', { count: stats.totalGames }) : t('home.games_played', { count: 0 })}
-                  </span>
-                </div>
-
-                <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-start">
+              <div className="mt-7 grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
+                <div className="flex flex-col gap-3 sm:flex-row">
                   <button
                     onClick={() => navigate(routes.quickPlay)}
                     onMouseEnter={() => void loadQuickPlayRoute()}
                     onFocus={() => void loadQuickPlayRoute()}
-                    className="button-accent-contrast w-full sm:w-auto min-w-[16rem] py-3.5 px-7 font-bold rounded-lg text-lg transition-colors shadow-md"
+                    className="button-accent-contrast w-full sm:w-auto min-w-[14rem] rounded-lg px-6 py-3.5 text-base font-bold transition-colors"
                   >
                     {t('home.quick_play')}
                   </button>
                   <button
-                    onClick={() => navigate(routes.leaderboard)}
-                    className="w-full sm:w-auto py-3.5 px-5 rounded-lg border border-surface-hover bg-surface hover:bg-surface-hover text-text-bright font-semibold transition-colors"
+                    onClick={openCreatePanel}
+                    className="w-full sm:w-auto rounded-lg border border-surface-hover/80 bg-surface px-6 py-3.5 text-base font-semibold text-text-bright transition-colors hover:bg-surface-hover"
                   >
-                    {t('leaderboard.title')}
+                    {t('home.create_private')}
                   </button>
-                  <p className="text-xs sm:text-sm text-text-dim">
-                    {t('quick.rated_available')}
-                  </p>
                 </div>
+                <button
+                  onClick={() => navigate(routes.leaderboard)}
+                  className="rounded-lg border border-surface-hover/80 bg-surface px-4 py-2.5 text-sm font-semibold text-text-dim transition-colors hover:bg-surface-hover hover:text-text-bright"
+                >
+                  {t('leaderboard.title')}
+                </button>
               </div>
+
+              <p className="mt-4 text-sm text-text-dim">{t('quick.rated_available')}</p>
             </div>
 
-            <aside className="grid gap-2.5 content-start">
-              <button
-                type="button"
-                onClick={() => navigate(routes.puzzleStreak)}
-                aria-label={`${t('home.puzzles')} ${t('home.puzzles_desc')}`}
-                className="min-h-[10.5rem] w-full rounded-xl border border-primary/20 bg-primary/10 px-4 py-4 text-left transition-colors hover:bg-primary/15"
-              >
-                <div className="flex items-start gap-3">
-                  <PuzzleSVG size={24} className="mt-0.5 flex-shrink-0 text-primary-light" />
-                  <div className="min-w-0">
-                    <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-primary-light">
-                      {t('home.streak_start')}
-                    </div>
-                    <div className="mt-1 text-[1rem] font-semibold text-text-bright">
-                      {t('home.streak_title')}
-                    </div>
-                    <div className="mt-1 text-xs text-text-dim sm:text-sm">
-                      {t('home.puzzles_desc')}
-                    </div>
-                  </div>
+            <aside className="grid content-start gap-3">
+              <div className="rounded-xl border border-surface-hover/70 bg-surface-alt p-4 sm:p-5">
+                <div className="mb-3 flex items-center gap-2.5">
+                  <FriendSVG size={22} className="text-text-bright flex-shrink-0" />
+                  <h2 className="text-base font-semibold text-text-bright">{t('home.create_private')}</h2>
                 </div>
-              </button>
 
-              {!showCreate ? (
-                <button
-                  type="button"
-                  onClick={openCreatePanel}
-                  className="bg-surface-alt border border-surface-hover/80 rounded-xl px-4 py-3.5 text-left transition-colors hover:bg-surface-hover/60"
-                >
-                  <div className="flex items-center gap-3">
-                    <FriendSVG size={24} className="text-text-bright flex-shrink-0" />
-                    <div>
-                      <div className="text-text-bright text-[0.95rem] font-semibold">{t('home.create_private')}</div>
-                      <div className="text-text-dim text-xs sm:text-sm">{t('home.private_desc')}</div>
-                    </div>
-                  </div>
-                </button>
-              ) : (
-                <div className="bg-surface-alt border border-surface-hover rounded-xl p-5">
-                  <div className="flex items-start justify-between gap-3 mb-4">
-                    <div>
-                      <h3 className="display text-lg font-semibold text-text-bright">{t('home.create_private')}</h3>
-                      <p className="text-text-dim text-sm mt-1">{t('home.private_desc')}</p>
-                    </div>
-                    <button
-                      type="button"
-                      onClick={() => setShowCreate(false)}
-                      className="text-text-dim hover:text-text-bright text-sm transition-colors"
-                    >
-                      {t('common.close')}
-                    </button>
-                  </div>
-
-                  <div className="mb-4">
-                    <label className="text-sm text-text-dim mb-2 block">{t('home.time_control')}</label>
-                    <div className="grid grid-cols-3 gap-2">
-                      {TIME_PRESETS.map((preset) => (
-                        <button
-                          key={preset.label}
-                          onClick={() => setSelectedTime(preset)}
-                          className={`
-                            py-2 px-3 rounded-lg text-sm font-medium transition-all
-                            ${selectedTime.label === preset.label
-                              ? 'bg-primary text-white shadow-md'
-                              : 'bg-surface hover:bg-surface-hover text-text border border-surface-hover'
-                            }
-                          `}
-                        >
-                          <div className="font-bold">{preset.label}</div>
-                          <div className="text-xs opacity-70">{t(preset.nameKey)}</div>
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-
-                  <div className="mb-4">
-                    <label className="text-sm text-text-dim mb-2 block">{t('home.choose_color')}</label>
-                    <div className="grid grid-cols-3 gap-2">
-                      {(['random', 'white', 'black'] as const).map((color) => (
-                        <button
-                          key={color}
-                          onClick={() => setSelectedColor(color)}
-                          className={`
-                            py-2 px-3 rounded-lg text-sm font-medium transition-all
-                            ${selectedColor === color
-                              ? 'bg-accent text-white shadow-md'
-                              : 'bg-surface hover:bg-surface-hover text-text border border-surface-hover'
-                            }
-                          `}
-                        >
-                          {t(`home.color_${color}`)}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-
+                <div className="mb-4 grid grid-cols-2 rounded-lg border border-surface-hover/70 bg-surface p-1">
                   <button
-                    onClick={handleCreateGame}
-                    disabled={isCreating}
-                    className="w-full py-3 px-6 bg-primary hover:bg-primary-light disabled:opacity-50 text-white font-bold rounded-lg transition-colors shadow-md"
+                    type="button"
+                    onClick={openCreatePanel}
+                    className={`rounded-md px-3 py-2 text-xs font-semibold transition-colors ${showCreate ? 'bg-surface-hover text-text-bright' : 'text-text-dim hover:text-text-bright'}`}
                   >
-                    {isCreating ? t('home.creating') : t('home.play_with_friend')}
+                    {t('home.create_private')}
                   </button>
-
-                  {createError && (
-                    <p className="mt-3 rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-sm text-danger">
-                      {createError}
-                    </p>
-                  )}
+                  <button
+                    type="button"
+                    onClick={openJoinPanel}
+                    className={`rounded-md px-3 py-2 text-xs font-semibold transition-colors ${showJoin ? 'bg-surface-hover text-text-bright' : 'text-text-dim hover:text-text-bright'}`}
+                  >
+                    {t('home.join_title')}
+                  </button>
                 </div>
-              )}
 
-              {!showJoin ? (
-                <button
-                  type="button"
-                  onClick={openJoinPanel}
-                  className="bg-surface-alt border border-surface-hover/80 rounded-xl px-4 py-3.5 text-left transition-colors hover:bg-surface-hover/60"
-                >
-                  <div className="text-text-bright text-[0.95rem] font-semibold">{t('home.join_title')}</div>
-                  <div className="text-text-dim text-xs sm:text-sm mt-1">{t('home.join_desc')}</div>
-                </button>
-              ) : (
-                <div className="bg-surface-alt border border-surface-hover rounded-xl p-5">
-                  <div className="flex items-start justify-between gap-3 mb-3">
-                    <div>
-                      <h3 className="display text-lg font-semibold text-text-bright">{t('home.join_title')}</h3>
-                      <p className="text-text-dim text-sm mt-1">{t('home.join_desc')}</p>
+                {showCreate ? (
+                  <>
+                    <div className="mb-4">
+                      <label className="mb-2 block text-sm text-text-dim">{t('home.time_control')}</label>
+                      <div className="grid grid-cols-3 gap-1.5">
+                        {TIME_PRESETS.map((preset) => (
+                          <button
+                            key={preset.label}
+                            onClick={() => setSelectedTime(preset)}
+                            className={`rounded-md border px-2 py-1.5 text-xs font-semibold transition-colors ${selectedTime.label === preset.label ? 'border-primary/40 bg-primary/12 text-primary-light' : 'border-surface-hover/70 bg-surface text-text-dim hover:text-text-bright'}`}
+                          >
+                            {preset.label}
+                          </button>
+                        ))}
+                      </div>
                     </div>
+
+                    <div className="mb-4">
+                      <label className="mb-2 block text-sm text-text-dim">{t('home.choose_color')}</label>
+                      <div className="grid grid-cols-3 gap-1.5">
+                        {(['random', 'white', 'black'] as const).map((color) => (
+                          <button
+                            key={color}
+                            onClick={() => setSelectedColor(color)}
+                            className={`rounded-md border px-2 py-1.5 text-xs font-semibold transition-colors ${selectedColor === color ? 'border-primary/40 bg-primary/12 text-primary-light' : 'border-surface-hover/70 bg-surface text-text-dim hover:text-text-bright'}`}
+                          >
+                            {t(`home.color_${color}`)}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+
                     <button
-                      type="button"
-                      onClick={() => setShowJoin(false)}
-                      className="text-text-dim hover:text-text-bright text-sm transition-colors"
+                      onClick={handleCreateGame}
+                      disabled={isCreating}
+                      className="button-primary-contrast w-full rounded-lg px-4 py-2.5 text-sm font-bold disabled:opacity-60"
                     >
-                      {t('common.close')}
+                      {isCreating ? t('home.creating') : t('home.play_with_friend')}
                     </button>
-                  </div>
+
+                    {createError && (
+                      <p className="mt-3 rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-sm text-danger">
+                        {createError}
+                      </p>
+                    )}
+                  </>
+                ) : (
                   <div className="flex gap-2">
                     <input
                       type="text"
@@ -493,79 +377,84 @@ export default function HomePage() {
                       onChange={(e) => setJoinId(e.target.value)}
                       onKeyDown={(e) => e.key === 'Enter' && handleJoinGame()}
                       placeholder={t('home.join_placeholder')}
-                      className="flex-1 bg-surface border border-surface-hover rounded-lg px-4 py-2 text-text-bright focus:outline-none focus:border-primary transition-colors"
+                      className="flex-1 rounded-lg border border-surface-hover/80 bg-surface px-3 py-2 text-sm text-text-bright"
                       autoFocus
                     />
                     <button
                       onClick={handleJoinGame}
-                      className="px-5 py-2 bg-accent hover:bg-accent/80 text-white font-semibold rounded-lg transition-colors"
+                      className="rounded-lg border border-primary/35 bg-primary/12 px-4 py-2 text-sm font-semibold text-primary-light transition-colors hover:bg-primary/18"
                     >
                       {t('home.join')}
                     </button>
                   </div>
+                )}
+              </div>
+
+              <button
+                type="button"
+                onClick={() => navigate(routes.puzzleStreak)}
+                aria-label={`${t('home.puzzles')} ${t('home.puzzles_desc')}`}
+                className="rounded-xl border border-primary/25 bg-primary/8 px-4 py-3.5 text-left transition-colors hover:bg-primary/12"
+              >
+                <div className="flex items-start gap-3">
+                  <PuzzleSVG size={22} className="mt-0.5 flex-shrink-0 text-primary-light" />
+                  <div>
+                    <div className="text-xs font-semibold uppercase tracking-[0.16em] text-primary-light">{t('home.streak_start')}</div>
+                    <div className="mt-1 text-sm font-semibold text-text-bright">{t('home.streak_title')}</div>
+                    <div className="mt-1 text-xs text-text-dim">{t('home.puzzles_desc')}</div>
+                  </div>
                 </div>
-              )}
+              </button>
 
               <button
                 type="button"
                 onClick={() => navigate(routes.bot)}
                 onMouseEnter={() => void loadBotGameRoute()}
                 onFocus={() => void loadBotGameRoute()}
-                className="rounded-xl border border-primary/20 bg-[linear-gradient(135deg,rgba(92,160,26,0.10),rgba(39,30,24,0.92)_45%,rgba(39,30,24,0.98))] px-4 py-3.5 text-left transition-colors hover:bg-surface-hover/60"
+                className="rounded-xl border border-surface-hover/80 bg-surface-alt px-4 py-3.5 text-left transition-colors hover:bg-surface-hover/50"
               >
                 <div className="flex items-center justify-between gap-3">
-                  <div className="flex items-center gap-3">
-                    <BotSVG size={24} className="text-text-bright flex-shrink-0" />
+                  <div className="flex items-center gap-2.5">
+                    <BotSVG size={22} className="text-text-bright flex-shrink-0" />
                     <div>
-                      <div className="text-text-bright text-[0.95rem] font-semibold">{t('home.play_bot')}</div>
-                      <div className="text-text-dim text-xs sm:text-sm">{t('home.play_bot_desc')}</div>
+                      <div className="text-sm font-semibold text-text-bright">{t('home.play_bot')}</div>
+                      <div className="text-xs text-text-dim">{t('home.play_bot_desc')}</div>
                     </div>
                   </div>
-                  <span className="rounded-full border border-primary/20 bg-primary/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-primary-light">
-                    1-10
-                  </span>
-                </div>
-                <div className="mt-3 text-[11px] leading-5 text-text-dim">{t('home.play_bot_long_desc')}</div>
-              </button>
-
-              <button
-                type="button"
-                onClick={() => navigate(routes.lessons)}
-                className="bg-surface-alt border border-surface-hover/80 rounded-xl px-4 py-3.5 text-left transition-colors hover:bg-surface-hover/60"
-              >
-                <div className="flex items-center gap-3">
-                  <PuzzleSVG size={24} className="text-text-bright flex-shrink-0" />
-                  <div>
-                    <div className="text-text-bright text-[0.95rem] font-semibold">{t('home.lessons')}</div>
-                    <div className="text-text-dim text-xs sm:text-sm">{t('home.lessons_desc')}</div>
-                  </div>
+                  <span className="rounded-full border border-primary/25 bg-primary/8 px-2 py-0.5 text-[10px] font-semibold text-primary-light">Lv 1-10</span>
                 </div>
               </button>
 
-              <button
-                type="button"
-                onClick={() => navigate(routes.watch)}
-                className="bg-surface-alt border border-surface-hover/80 rounded-xl px-4 py-3.5 text-left transition-colors hover:bg-surface-hover/60"
-              >
-                <div className="flex items-center gap-3">
-                  <QuickPlaySVG size={24} className="text-text-bright flex-shrink-0" />
-                  <div>
-                    <div className="text-text-bright text-[0.95rem] font-semibold">{t('home.watch_live')}</div>
-                    <div className="text-text-dim text-xs sm:text-sm">{t('home.watch_live_desc')}</div>
-                  </div>
+              <div className="rounded-xl border border-surface-hover/80 bg-surface-alt p-4">
+                <div className="mb-3 text-xs font-semibold uppercase tracking-[0.16em] text-text-dim">{t('home.learn_eyebrow')}</div>
+                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-1">
+                  <button
+                    type="button"
+                    onClick={() => navigate(routes.lessons)}
+                    className="flex items-center gap-2 rounded-lg border border-surface-hover/70 bg-surface px-3 py-2 text-left text-sm font-semibold text-text-bright transition-colors hover:bg-surface-hover"
+                  >
+                    <PuzzleSVG size={18} className="text-text-dim" />
+                    {t('home.lessons')}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => navigate(routes.watch)}
+                    className="flex items-center gap-2 rounded-lg border border-surface-hover/70 bg-surface px-3 py-2 text-left text-sm font-semibold text-text-bright transition-colors hover:bg-surface-hover"
+                  >
+                    <QuickPlaySVG size={18} className="text-text-dim" />
+                    {t('home.watch_live')}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => navigate(routes.local)}
+                    onMouseEnter={() => void loadLocalGameRoute()}
+                    onFocus={() => void loadLocalGameRoute()}
+                    className="rounded-lg border border-surface-hover/70 bg-surface px-3 py-2 text-left text-sm font-semibold text-text-bright transition-colors hover:bg-surface-hover"
+                  >
+                    {t('home.play_local')}
+                  </button>
                 </div>
-              </button>
-
-              <button
-                type="button"
-                onClick={() => navigate(routes.local)}
-                onMouseEnter={() => void loadLocalGameRoute()}
-                onFocus={() => void loadLocalGameRoute()}
-                className="bg-surface-alt border border-surface-hover/80 rounded-xl px-4 py-3.5 text-left transition-colors hover:bg-surface-hover/60"
-              >
-                <div className="text-text-bright text-[0.95rem] font-semibold">{t('home.play_local')}</div>
-                <div className="text-text-dim text-xs sm:text-sm mt-1">{t('home.play_local_desc')}</div>
-              </button>
+              </div>
             </aside>
           </section>
 

--- a/client/src/components/HomePage.tsx
+++ b/client/src/components/HomePage.tsx
@@ -247,15 +247,15 @@ export default function HomePage() {
       <main id="main-content" className="flex-1 px-4 py-8 sm:px-6 sm:py-10">
         <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 sm:gap-8">
           <section className="grid gap-4 lg:grid-cols-[minmax(0,1.45fr)_330px]">
-            <div className="rounded-2xl border border-surface-hover/70 bg-surface-alt p-6 sm:p-8 lg:p-10">
+            <div className="ui-card rounded-2xl p-6 sm:p-8 lg:p-10">
               <p className="text-xs font-semibold uppercase tracking-[0.22em] text-accent">
                 {t('nav.play')}
               </p>
 
-              <h1 className="mt-3 max-w-3xl text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-text-bright">
+              <h1 className="ui-title mt-3 max-w-3xl text-3xl sm:text-4xl lg:text-5xl">
                 {t('home.hero_title')}
               </h1>
-              <p className="mt-4 max-w-2xl text-base sm:text-lg text-text-dim leading-7">
+              <p className="ui-body mt-4 max-w-2xl text-base sm:text-lg">
                 {t('home.hero_desc')}
               </p>
 
@@ -283,14 +283,14 @@ export default function HomePage() {
                   </button>
                   <button
                     onClick={openCreatePanel}
-                    className="w-full sm:w-auto rounded-lg border border-surface-hover/80 bg-surface px-6 py-3.5 text-base font-semibold text-text-bright transition-colors hover:bg-surface-hover"
+                    className="ui-btn-secondary w-full sm:w-auto px-6 py-3.5 text-base"
                   >
                     {t('home.create_private')}
                   </button>
                 </div>
                 <button
                   onClick={() => navigate(routes.leaderboard)}
-                  className="rounded-lg border border-surface-hover/80 bg-surface px-4 py-2.5 text-sm font-semibold text-text-dim transition-colors hover:bg-surface-hover hover:text-text-bright"
+                  className="ui-btn-secondary px-4 py-2.5 text-sm text-text-dim hover:text-text-bright"
                 >
                   {t('leaderboard.title')}
                 </button>
@@ -300,7 +300,7 @@ export default function HomePage() {
             </div>
 
             <aside className="grid content-start gap-3">
-              <div className="rounded-xl border border-surface-hover/70 bg-surface-alt p-4 sm:p-5">
+              <div className="ui-card p-4 sm:p-5">
                 <div className="mb-3 flex items-center gap-2.5">
                   <FriendSVG size={22} className="text-text-bright flex-shrink-0" />
                   <h2 className="text-base font-semibold text-text-bright">{t('home.create_private')}</h2>
@@ -411,7 +411,7 @@ export default function HomePage() {
                 onClick={() => navigate(routes.bot)}
                 onMouseEnter={() => void loadBotGameRoute()}
                 onFocus={() => void loadBotGameRoute()}
-                className="rounded-xl border border-surface-hover/80 bg-surface-alt px-4 py-3.5 text-left transition-colors hover:bg-surface-hover/50"
+                className="ui-card px-4 py-3.5 text-left transition-colors hover:bg-surface-hover/50"
               >
                 <div className="flex items-center justify-between gap-3">
                   <div className="flex items-center gap-2.5">
@@ -425,13 +425,13 @@ export default function HomePage() {
                 </div>
               </button>
 
-              <div className="rounded-xl border border-surface-hover/80 bg-surface-alt p-4">
+              <div className="ui-card p-4">
                 <div className="mb-3 text-xs font-semibold uppercase tracking-[0.16em] text-text-dim">{t('home.learn_eyebrow')}</div>
                 <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-1">
                   <button
                     type="button"
                     onClick={() => navigate(routes.lessons)}
-                    className="flex items-center gap-2 rounded-lg border border-surface-hover/70 bg-surface px-3 py-2 text-left text-sm font-semibold text-text-bright transition-colors hover:bg-surface-hover"
+                    className="ui-btn-secondary flex items-center gap-2 px-3 py-2 text-left text-sm"
                   >
                     <PuzzleSVG size={18} className="text-text-dim" />
                     {t('home.lessons')}
@@ -439,7 +439,7 @@ export default function HomePage() {
                   <button
                     type="button"
                     onClick={() => navigate(routes.watch)}
-                    className="flex items-center gap-2 rounded-lg border border-surface-hover/70 bg-surface px-3 py-2 text-left text-sm font-semibold text-text-bright transition-colors hover:bg-surface-hover"
+                    className="ui-btn-secondary flex items-center gap-2 px-3 py-2 text-left text-sm"
                   >
                     <QuickPlaySVG size={18} className="text-text-dim" />
                     {t('home.watch_live')}
@@ -449,7 +449,7 @@ export default function HomePage() {
                     onClick={() => navigate(routes.local)}
                     onMouseEnter={() => void loadLocalGameRoute()}
                     onFocus={() => void loadLocalGameRoute()}
-                    className="rounded-lg border border-surface-hover/70 bg-surface px-3 py-2 text-left text-sm font-semibold text-text-bright transition-colors hover:bg-surface-hover"
+                    className="ui-btn-secondary px-3 py-2 text-left text-sm"
                   >
                     {t('home.play_local')}
                   </button>
@@ -460,7 +460,7 @@ export default function HomePage() {
 
           <div ref={deferredContentRef}>
             {showDeferredContent ? (
-              <Suspense fallback={<section className="deferred-section rounded-2xl border border-surface-hover bg-surface-alt/85 p-5 sm:p-6 min-h-[18rem]"><div className="h-10 w-40 rounded-lg bg-surface" /></section>}>
+              <Suspense fallback={<section className="deferred-section ui-card rounded-2xl p-5 sm:p-6 min-h-[18rem]"><div className="h-10 w-40 rounded-lg bg-surface" /></section>}>
                 <DeferredLiveGamesPanel
                   games={liveGames}
                   loading={liveGamesLoading}
@@ -475,7 +475,7 @@ export default function HomePage() {
                 />
               </Suspense>
             ) : (
-              <section aria-hidden="true" className="deferred-section rounded-2xl border border-surface-hover bg-surface-alt/85 p-5 sm:p-6 min-h-[18rem]">
+              <section aria-hidden="true" className="deferred-section ui-card rounded-2xl p-5 sm:p-6 min-h-[18rem]">
                 <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
                   <div className="space-y-3">
                     <div className="h-4 w-24 rounded-full bg-surface" />
@@ -488,13 +488,13 @@ export default function HomePage() {
             )}
           </div>
 
-          <section className="deferred-section rounded-2xl border border-surface-hover bg-surface-alt/85 p-5 sm:p-6">
+          <section className="deferred-section ui-card rounded-2xl p-5 sm:p-6">
             <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
               <div>
-                <p className="text-xs font-semibold uppercase tracking-[0.22em] text-accent">
+                <p className="ui-eyebrow">
                   {t('home.learn_eyebrow')}
                 </p>
-                <h2 className="mt-2 text-2xl font-bold text-text-bright">
+                <h2 className="ui-title mt-2 text-2xl">
                   {t('home.learn_title')}
                 </h2>
               </div>
@@ -508,7 +508,7 @@ export default function HomePage() {
                 <a
                   key={card.href}
                   href={card.href}
-                  className="rounded-2xl border border-surface-hover bg-surface/55 px-4 py-4 transition-colors hover:bg-surface-hover"
+                  className="ui-card-soft rounded-2xl px-4 py-4 transition-colors hover:bg-surface-hover"
                 >
                   <div className="text-lg font-semibold text-text-bright">{card.title}</div>
                   <div className="mt-2 text-sm leading-6 text-text-dim">{card.desc}</div>

--- a/client/src/components/QuickPlay.tsx
+++ b/client/src/components/QuickPlay.tsx
@@ -180,7 +180,7 @@ export default function QuickPlay() {
 
       <main id="main-content" className="flex-1 flex items-center justify-center px-4 py-8">
         {searching ? (
-          <div className="bg-surface-alt border border-surface-hover rounded-xl p-6 sm:p-8 w-full max-w-md text-center animate-slideUp">
+          <div className="ui-card w-full max-w-md p-6 text-center animate-slideUp sm:p-8">
             <div className="w-16 h-16 border-4 border-primary border-t-transparent rounded-full animate-spin mx-auto mb-6" />
             <h2 className="text-2xl font-bold text-text-bright mb-2">{t('quick.searching')}</h2>
             <p className="text-text-dim mb-1">
@@ -207,7 +207,7 @@ export default function QuickPlay() {
                   </button>
                   <button
                     onClick={() => setFallbackDismissed(true)}
-                    className="rounded-lg border border-surface-hover bg-surface px-4 py-2 text-sm font-semibold text-text-bright transition-colors hover:bg-surface-hover"
+                    className="ui-btn-secondary px-4 py-2 text-sm"
                   >
                     {t('quick.keep_searching')}
                   </button>
@@ -217,14 +217,14 @@ export default function QuickPlay() {
             <div className="flex gap-3 mt-6">
               <button
                 onClick={handleCancel}
-                className="flex-1 py-3 px-6 bg-surface-hover hover:bg-danger/20 text-text-bright hover:text-danger font-semibold rounded-lg transition-colors border border-surface-hover"
+                className="ui-btn-secondary flex-1 px-6 py-3 hover:bg-danger/20 hover:text-danger"
               >
                 {t('common.cancel')}
               </button>
             </div>
           </div>
         ) : (
-          <div className="bg-surface-alt border border-surface-hover rounded-xl p-5 sm:p-6 w-full max-w-lg animate-slideUp">
+          <div className="ui-card w-full max-w-lg p-5 animate-slideUp sm:p-6">
             <h2 className="text-2xl font-bold text-text-bright mb-2 text-center">{t('quick.title')}</h2>
             <p className="text-text-dim text-center mb-6 text-sm">{t('quick.desc')}</p>
             <div className="mb-6 rounded-xl border border-surface-hover bg-surface px-4 py-3 text-center">
@@ -286,7 +286,7 @@ export default function QuickPlay() {
 
             <button
               onClick={() => navigate(routes.home)}
-              className="w-full mt-3 py-2 px-6 bg-surface hover:bg-surface-hover text-text border border-surface-hover font-medium rounded-lg transition-colors"
+              className="ui-btn-secondary mt-3 w-full px-6 py-2"
             >
               {t('common.back_home')}
             </button>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -357,6 +357,64 @@
     background: oklch(0.72 0.15 75);
   }
 
+  .ui-card {
+    border: 1px solid color-mix(in oklab, var(--color-surface-hover) 70%, transparent);
+    border-radius: 0.9rem;
+    background: color-mix(in oklab, var(--color-surface-alt) 92%, transparent);
+  }
+
+  .ui-card-soft {
+    border: 1px solid color-mix(in oklab, var(--color-surface-hover) 62%, transparent);
+    border-radius: 0.75rem;
+    background: color-mix(in oklab, var(--color-surface) 88%, transparent);
+  }
+
+  .ui-eyebrow {
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--color-accent);
+  }
+
+  .ui-title {
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    color: var(--color-text-bright);
+  }
+
+  .ui-body {
+    color: var(--color-text-dim);
+    line-height: 1.6;
+  }
+
+  .ui-btn-primary {
+    border-radius: 0.6rem;
+    border: 1px solid color-mix(in oklab, var(--color-primary) 35%, transparent);
+    background: color-mix(in oklab, var(--color-primary) 18%, transparent);
+    color: var(--color-primary-light);
+    font-weight: 700;
+    transition: background-color 160ms ease, border-color 160ms ease;
+  }
+
+  .ui-btn-primary:hover {
+    background: color-mix(in oklab, var(--color-primary) 24%, transparent);
+    border-color: color-mix(in oklab, var(--color-primary) 42%, transparent);
+  }
+
+  .ui-btn-secondary {
+    border-radius: 0.6rem;
+    border: 1px solid color-mix(in oklab, var(--color-surface-hover) 78%, transparent);
+    background: var(--color-surface);
+    color: var(--color-text-bright);
+    font-weight: 600;
+    transition: background-color 160ms ease, color 160ms ease;
+  }
+
+  .ui-btn-secondary:hover {
+    background: var(--color-surface-hover);
+  }
+
   .deferred-section {
     content-visibility: auto;
     contain-intrinsic-size: 720px;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -496,150 +496,16 @@
   animation: slideOut 0.3s ease-in;
 }
 
-/* ─── Bot Page Animations ──────────────────────────────────────────── */
+/* ─── Calm Interaction Helpers ─────────────────────────────────────── */
 
-/* Card entrance animation - staggered */
-@keyframes cardEntrance {
-  from {
-    opacity: 0;
-    transform: translateY(20px) scale(0.96);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-}
-
-.animate-card-entrance {
-  animation: cardEntrance 0.5s ease-out forwards;
-  opacity: 0;
-}
-
-/* Avatar breathing animation */
-@keyframes avatarBreathe {
-  0%, 100% {
-    transform: scale(1);
-  }
-  50% {
-    transform: scale(1.03);
-  }
-}
-
-.animate-breathe {
-  animation: avatarBreathe 4s ease-in-out infinite;
-}
-
-/* Selection pulse ring */
-@keyframes selectionPulse {
-  0%, 100% {
-    box-shadow: 0 0 0 0 oklch(0.58 0.16 135 / 0.4);
-  }
-  50% {
-    box-shadow: 0 0 0 8px oklch(0.58 0.16 135 / 0);
-  }
-}
-
-.animate-selection-pulse {
-  animation: selectionPulse 2s ease-in-out infinite;
-}
-
-/* Avatar "wake up" animation when selected */
-@keyframes avatarWakeUp {
-  0% {
-    transform: scale(1) rotate(0deg);
-  }
-  25% {
-    transform: scale(1.12) rotate(-4deg);
-  }
-  50% {
-    transform: scale(1.18) rotate(4deg);
-  }
-  75% {
-    transform: scale(1.12) rotate(0deg);
-  }
-  100% {
-    transform: scale(1.1) rotate(0deg);
-  }
-}
-
-.animate-wake-up {
-  animation: avatarWakeUp 0.6s ease-out forwards;
-}
-
-/* Play button pulse */
-@keyframes playButtonPulse {
-  0%, 100% {
-    box-shadow: 0 8px 24px rgba(92, 160, 26, 0.35);
-  }
-  50% {
-    box-shadow: 0 8px 32px rgba(92, 160, 26, 0.5);
-  }
-}
-
-.animate-play-pulse {
-  animation: playButtonPulse 2s ease-in-out infinite;
-}
-
-/* Shimmer effect for play button */
-@keyframes shimmer {
-  0% {
-    background-position: -200% center;
-  }
-  100% {
-    background-position: 200% center;
-  }
-}
-
-.animate-shimmer {
-  background: linear-gradient(
-    90deg,
-    var(--color-primary) 0%,
-    var(--color-primary-light) 25%,
-    var(--color-primary) 50%,
-    var(--color-primary-light) 75%,
-    var(--color-primary) 100%
-  );
-  background-size: 200% auto;
-  animation: shimmer 3s linear infinite;
-}
-
-/* Content fade in for details panel */
-@keyframes contentFadeIn {
-  from {
-    opacity: 0;
-    transform: translateY(-10px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.animate-content-fade {
-  animation: contentFadeIn 0.3s ease-out forwards;
-}
-
-/* Hover lift effect */
 .hover-lift {
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
 }
 
 .hover-lift:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.2);
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.14);
 }
-
-/* Stagger delay utilities */
-.stagger-1 { animation-delay: 0.05s; }
-.stagger-2 { animation-delay: 0.1s; }
-.stagger-3 { animation-delay: 0.15s; }
-.stagger-4 { animation-delay: 0.2s; }
-.stagger-5 { animation-delay: 0.25s; }
-.stagger-6 { animation-delay: 0.3s; }
-.stagger-7 { animation-delay: 0.35s; }
-.stagger-8 { animation-delay: 0.4s; }
-.stagger-9 { animation-delay: 0.45s; }
-.stagger-10 { animation-delay: 0.5s; }
 
 /* Hide scrollbar utility for mobile carousel */
 .scrollbar-hide {

--- a/client/src/test/HomePage.test.tsx
+++ b/client/src/test/HomePage.test.tsx
@@ -158,7 +158,7 @@ describe('HomePage', () => {
     const Wrapper = createWrapper();
     render(<HomePage />, { wrapper: Wrapper });
 
-    expect(screen.getByText('Human match when available, bot fallback when it is quiet.')).toBeInTheDocument();
+    expect(screen.getByText('No signup required. Start a ThaiChess game, play with friends, or practice against the bot.')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /play now/i })).toBeInTheDocument();
     expect(screen.queryByText(/get paired instantly/i)).not.toBeInTheDocument();
   });
@@ -170,7 +170,7 @@ describe('HomePage', () => {
     const Wrapper = createWrapper();
     render(<HomePage />, { wrapper: Wrapper });
 
-    expect(screen.getByText('คู่มือเริ่มต้น')).toBeInTheDocument();
+    expect(screen.getAllByText('คู่มือเริ่มต้น').length).toBeGreaterThan(0);
     expect(screen.getByText('เริ่มจากหน้าที่อ่านแล้วเข้าใจจริง')).toBeInTheDocument();
     expect(screen.getAllByText('หมากรุกไทยคืออะไร').length).toBeGreaterThan(0);
     expect(screen.getAllByText('วิธีเล่นหมากรุกไทย').length).toBeGreaterThan(0);
@@ -178,7 +178,8 @@ describe('HomePage', () => {
   });
 
   function openCreatePanel() {
-    fireEvent.click(screen.getByRole('button', { name: /create a private game/i }));
+    const createButtons = screen.getAllByRole('button', { name: /create a private game/i });
+    fireEvent.click(createButtons[0]!);
   }
 
   it('cleans up create-game socket listeners on unmount', async () => {

--- a/client/src/test/botEngine.test.ts
+++ b/client/src/test/botEngine.test.ts
@@ -74,7 +74,7 @@ describe('botEngine', () => {
       const legalMoves = getLegalMoves(state.board, move!.from);
       expect(legalMoves).toContainEqual(move!.to);
     }
-  });
+  }, 15_000);
 
   it('scales search configuration by level while keeping all levels bounded', () => {
     const beginner = getBotLevelConfig(1);


### PR DESCRIPTION
## What does this PR do?

Declutters the home UX by simplifying navigation, introducing reusable phase-2 UI primitives (`ui-btn-secondary`, `ui-card`, `ui-card-soft`), and replacing inline footers with the shared `<Footer />` component across `HomePage`, `GamesPage`, `AboutPage`, `QuickPlay`, and `FeedbackMessagesPage`.

Commits:
- `feat:` declutter home UX and simplify navigation
- `style:` add phase-2 UI primitives and normalize surfaces
- `refactor:` adopt UI primitives and shared Footer in GamesPage
- `refactor:` use shared Footer component in AboutPage and FeedbackMessagesPage

## Type of Change

- [x] Refactoring

## Checklist

- [x] Code compiles without errors
- [x] Client builds successfully
- [x] Tested locally (build + smoke tested)