### PR TITLE
fix: trust external engine for bot levels 11-12

### DIFF
--- a/server/src/engineGateway.ts
+++ b/server/src/engineGateway.ts
@@ -314,6 +314,10 @@ export function createHighLevelBotSearchPlan(snapshot: AnalysisPositionSnapshot,
 
 export const createLevel10BotSearchPlan = createHighLevelBotSearchPlan;
 
+export function shouldApplyHighLevelEngineOverride(level: number): boolean {
+  return clampBotLevel(level) === 10;
+}
+
 function createExternalBotSearch(
   snapshot: AnalysisPositionSnapshot,
   level: number,
@@ -876,7 +880,7 @@ export async function getBotMoveWithEngine(
     const resolved = resolveBotMoveCandidate(snapshot, normalizedLevel, parsedMove, botId);
 
     if (resolved.source === 'engine') {
-      const validated = normalizedLevel >= 10
+      const validated = shouldApplyHighLevelEngineOverride(normalizedLevel)
         ? validateHighLevelEngineMove(snapshot, normalizedLevel, resolved.move!, botId)
         : { move: resolved.move!, source: 'engine' as const, depth: result.depth };
 

--- a/server/src/test/fairyStockfishBinary.test.ts
+++ b/server/src/test/fairyStockfishBinary.test.ts
@@ -14,6 +14,7 @@ import {
   normalizeEngineMate,
   resolveBotMoveCandidate,
   resolvePositionAnalysisResult,
+  shouldApplyHighLevelEngineOverride,
 } from '../engineGateway';
 
 describe('normalizeEngineFen', () => {
@@ -189,6 +190,12 @@ describe('normalizeEngineFen', () => {
     expect(result.evaluation).toBe(-280);
     expect(result.mate).toBe(-5);
     expect(result.bestMove).toEqual(legalMove);
+  });
+
+  it('applies local engine override only for level 10', () => {
+    expect(shouldApplyHighLevelEngineOverride(10)).toBe(true);
+    expect(shouldApplyHighLevelEngineOverride(11)).toBe(false);
+    expect(shouldApplyHighLevelEngineOverride(12)).toBe(false);
   });
 
   it('uses bounded Level 10 depth search in check and endgame positions', () => {


### PR DESCRIPTION
## What does this PR do?

Brief description of the changes.

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] Code compiles without errors (`npx tsc --noEmit`)
- [ ] Client builds successfully (`npm run build --workspace=client`)
- [ ] Tested locally
- [ ] No console errors in browser
